### PR TITLE
Add html-email-formatter package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Open source libraries and configurations used at [Customer.io](https://customer.
 
 - [@ciolabs/config-eslint](./packages/config-eslint) - Shared ESLint configuration for Customer.io projects
 - [@ciolabs/config-prettier](./packages/config-prettier) - Shared Prettier configuration for Customer.io projects
+- [@ciolabs/html-email-formatter](./packages/html-email-formatter) - Format and prettify HTML email content with conditional comment support
 - [@ciolabs/html-find-conditional-comments](./packages/html-find-conditional-comments) - Finds all conditional comments in a string
 - [@ciolabs/html-preserve-comment-whitespace](./packages/html-preserve-comment-whitespace) - Preserves the presence or lack thereof of whitespace surrounding HTML comments
 - [@ciolabs/html-process-conditional-comments](./packages/html-process-conditional-comments) - Makes it easy to safely process HTML inside of conditional comments

--- a/packages/html-email-formatter/package.json
+++ b/packages/html-email-formatter/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@ciolabs/html-email-formatter",
+  "version": "0.0.0",
+  "description": "Format and prettify HTML email content",
+  "author": "Customer.io <win@customer.io>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/customerio/ciolabs.git",
+    "directory": "packages/html-email-formatter"
+  },
+  "homepage": "https://github.com/customerio/ciolabs/tree/main/packages/html-email-formatter#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ciolabs/html-find-conditional-comments": "workspace:*",
+    "@ciolabs/html-preserve-comment-whitespace": "workspace:*",
+    "@types/js-beautify": "^1.13.3",
+    "@types/pretty": "^2.0.1",
+    "js-beautify": "^1.15.1",
+    "magic-string": "^0.30.0",
+    "pretty": "^2.0.0"
+  }
+}

--- a/packages/html-email-formatter/src/index.test.ts
+++ b/packages/html-email-formatter/src/index.test.ts
@@ -35,7 +35,13 @@ test('email formatter should respect the whitespace', () => {
     <div> <!--[if MAC]> hello    <![endif]-->      </div>
   `);
 
-  expect(result).toBe(`<div> <!--[if MAC]> hello    <![endif]-->      </div>`);
+  expect(result).toBe(`<div> <!--[if MAC]> hello <![endif]--> </div>`);
+});
+
+test('should keep no whitespace if there was none', () => {
+  const result = emailFormatter(`<div><!--[if MAC]>hello<![endif]--></div>`);
+
+  expect(result).toBe(`<div><!--[if MAC]>hello<![endif]--></div>`);
 });
 
 test('email formatter should properly format from a single line', () => {

--- a/packages/html-email-formatter/src/index.test.ts
+++ b/packages/html-email-formatter/src/index.test.ts
@@ -1,0 +1,72 @@
+import { test, expect } from 'vitest';
+
+import emailFormatter from './index';
+
+test('email formatter should align the open and close tags', () => {
+  const result = emailFormatter(`
+    <div>
+    <!--[if MAC]>
+    <div>
+    <span>
+    <![endif]-->
+    <!--[if MAC]>
+    </span>
+    </div>
+    <![endif]-->
+    </div>
+  `);
+
+  expect(result).toBe(
+    `<div>
+  <!--[if MAC]>
+  <div>
+    <span>
+  <![endif]-->
+  <!--[if MAC]>
+    </span>
+  </div>
+  <![endif]-->
+</div>`
+  );
+});
+
+test('email formatter should respect the whitespace', () => {
+  const result = emailFormatter(`
+    <div> <!--[if MAC]> hello    <![endif]-->      </div>
+  `);
+
+  expect(result).toBe(`<div> <!--[if MAC]> hello    <![endif]-->      </div>`);
+});
+
+test('email formatter should properly format from a single line', () => {
+  const result = emailFormatter(`<!DOCTYPE html>
+  <html style="">
+  
+    <body class="">
+  
+      <!--[if mso]><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td style="background-color: rgb(255, 255, 255);"><![endif]-->
+  
+      <!--[if mso]></td></tr></table><![endif]-->
+     
+       </body>
+  </html>`);
+
+  expect(result).toBe(
+    `<!DOCTYPE html>
+<html style="">
+
+  <body class="">
+
+    <!--[if mso]><table cellpadding="0" cellspacing="0" border="0" width="100%">
+      <tr>
+    <td style="background-color: rgb(255, 255, 255);"><![endif]-->
+
+    <!--[if mso]></td>
+      </tr>
+    </table><![endif]-->
+
+  </body>
+
+</html>`
+  );
+});

--- a/packages/html-email-formatter/src/index.ts
+++ b/packages/html-email-formatter/src/index.ts
@@ -1,0 +1,124 @@
+import findConditionalComments from '@ciolabs/html-find-conditional-comments';
+import { preserve, restore } from '@ciolabs/html-preserve-comment-whitespace';
+import jsBeautify from 'js-beautify';
+import MagicString from 'magic-string';
+import pretty from 'pretty';
+
+export default function emailFormatter(
+  html: string,
+  options?: Parameters<typeof pretty>[1] & jsBeautify.HTMLBeautifyOptions
+): string {
+  const id = Math.random();
+  const opener = `<!--${id}`;
+  const closer = `${id}-->`;
+
+  html = closeConditionalComments(html, { opener, closer });
+
+  const cache = preserve(html);
+  html = pretty(html, options);
+  html = restore(html, cache);
+  html = openConditionalComments(html, { opener, closer });
+  html = alignOpenAndCloseOfConditionalComments(html);
+
+  return html;
+}
+
+/**
+ * Close downlevel-hidden conditional comments
+ *
+ * Example:
+ * <!--[if mso]>
+ *  <p>Content</p>
+ * <![endif]-->
+ *
+ * Becomes:
+ * <!--[if mso]>123456789-->
+ * <p>Content</p>
+ * <!--123456789<![endif]-->
+ *
+ * This opens the the MSO HTML to be formatted by the HTML formatter.
+ */
+function closeConditionalComments(html: string, { opener, closer }: { opener: string; closer: string }) {
+  const comments = findConditionalComments(html);
+  const s = new MagicString(html);
+
+  for (const comment of comments) {
+    const contentStartIndex = comment.range[0] + comment.open.length;
+    const contentEndIndex = comment.range[1] - comment.close.length;
+
+    s.appendLeft(contentStartIndex, closer);
+    s.appendLeft(contentEndIndex, opener);
+  }
+
+  return s.toString();
+}
+
+/**
+ * Open downlevel-hidden conditional comments
+ *
+ * Example:
+ * <!--[if mso]>123456789-->
+ * <p>Content</p>
+ * <!--123456789<![endif]-->
+ *
+ * Becomes:
+ * <!--[if mso]>
+ * <p>Content</p>
+ * <![endif]-->
+ *
+ * This reverses the effect of `closeConditionalComments`. After the HTML
+ * formatter has formatted the MSO HTML, we restore the original state.
+ */
+function openConditionalComments(html: string, { opener, closer }: { opener: string; closer: string }) {
+  return html.replaceAll(new RegExp(`(${opener}|${closer})`, 'g'), '');
+}
+
+/**
+ * Align open and close tags of conditional comments
+ */
+function alignOpenAndCloseOfConditionalComments(html: string) {
+  const comments = findConditionalComments(html);
+  const s = new MagicString(html);
+
+  for (const comment of comments) {
+    const code = new Set(html.slice(comment.range[0], comment.range[1]));
+    if (!code.has('\n') && !code.has('\r')) {
+      continue;
+    }
+
+    const { whitespace: openLeadingWhitespace } = parseWhitespaceAndTextOfLastLine(
+      html.slice(0, Math.max(0, comment.range[0]))
+    );
+    const { whitespace: closeLeadingWhitespace, text: closeLeadingText } = parseWhitespaceAndTextOfLastLine(
+      html.slice(comment.range[0], comment.range[1] - comment.close.length)
+    );
+
+    if (openLeadingWhitespace.length === closeLeadingWhitespace.length) {
+      continue;
+    }
+
+    if (openLeadingWhitespace.length > closeLeadingWhitespace.length) {
+      s.overwrite(comment.range[0] - openLeadingWhitespace.length, comment.range[0], closeLeadingWhitespace);
+    } else {
+      s.overwrite(
+        comment.range[1] - comment.close.length - closeLeadingText.length - closeLeadingWhitespace.length,
+        comment.range[1] - comment.close.length - closeLeadingText.length,
+        openLeadingWhitespace
+      );
+    }
+  }
+
+  return s.toString();
+}
+
+function parseWhitespaceAndTextOfLastLine(string_: string): {
+  whitespace: string;
+  text: string;
+} {
+  const lastLine = string_.split('\n').at(-1) ?? '';
+  const match = /^[^\S\n\r]*/.exec(lastLine);
+  const whitespace = match ? match[0] : '';
+  const text = lastLine.slice(whitespace.length);
+
+  return { whitespace, text };
+}

--- a/packages/html-email-formatter/tsconfig.json
+++ b/packages/html-email-formatter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/html-email-formatter/tsup.config.ts
+++ b/packages/html-email-formatter/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+import baseConfig from '../../tsup.config';
+
+export default defineConfig({
+  ...baseConfig,
+  entry: ['src/index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,30 @@ importers:
         specifier: ^5.0.0
         version: 5.9.2
 
+  packages/html-email-formatter:
+    dependencies:
+      '@ciolabs/html-find-conditional-comments':
+        specifier: workspace:*
+        version: link:../html-find-conditional-comments
+      '@ciolabs/html-preserve-comment-whitespace':
+        specifier: workspace:*
+        version: link:../html-preserve-comment-whitespace
+      '@types/js-beautify':
+        specifier: ^1.13.3
+        version: 1.14.3
+      '@types/pretty':
+        specifier: ^2.0.1
+        version: 2.0.3
+      js-beautify:
+        specifier: ^1.15.1
+        version: 1.15.4
+      magic-string:
+        specifier: ^0.30.0
+        version: 0.30.19
+      pretty:
+        specifier: ^2.0.0
+        version: 2.0.0
+
   packages/html-find-conditional-comments: {}
 
   packages/html-mod:
@@ -624,6 +648,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -766,6 +793,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/js-beautify@1.14.3':
+    resolution: {integrity: sha512-FMbQHz+qd9DoGvgLHxeqqVPaNRffpIu5ZjozwV8hf9JAGpIOzuAf4wGbRSo8LNITHqGjmmVjaMggTT5P4v4IHg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -780,6 +810,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/pretty@2.0.3':
+    resolution: {integrity: sha512-xR96pShNlrxLd3gZqzCnbaAmbYhiRYjW51CDFjektZemqpBZBAAkMwxm4gBraJP/xSgKcsQhLXdlXOwDNWo4VQ==}
 
   '@typescript-eslint/eslint-plugin@8.44.0':
     resolution: {integrity: sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==}
@@ -966,6 +999,10 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1190,6 +1227,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -1201,8 +1242,15 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  condense-newlines@0.2.1:
+    resolution: {integrity: sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==}
+    engines: {node: '>=0.10.0'}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -1321,6 +1369,11 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.4:
+    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   electron-to-chromium@1.5.220:
     resolution: {integrity: sha512-TWXijEwR1ggr4BdAKrb1nMNqYLTx1/4aD1fkeZU+FVJGTKu53/T7UyHKXlqEX3Ub02csyHePbHmkvnrjcaYzMA==}
@@ -1597,6 +1650,10 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -1838,6 +1895,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -1861,6 +1921,9 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
   is-builtin-module@3.2.1:
     resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
     engines: {node: '>=6'}
@@ -1883,6 +1946,10 @@ packages:
   is-date-object@1.1.0:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1976,6 +2043,10 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-whitespace@0.3.0:
+    resolution: {integrity: sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==}
+    engines: {node: '>=0.10.0'}
+
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
@@ -1999,6 +2070,15 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2058,6 +2138,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@3.2.2:
+    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
+    engines: {node: '>=0.10.0'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -2175,6 +2259,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@9.0.1:
+    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2226,6 +2314,11 @@ packages:
 
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
+
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -2438,8 +2531,15 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty@2.0.0:
+    resolution: {integrity: sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==}
+    engines: {node: '>=0.10.0'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3592,6 +3692,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -3694,6 +3796,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/js-beautify@1.14.3': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -3705,6 +3809,8 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/pretty@2.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
@@ -3901,6 +4007,8 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  abbrev@2.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -4140,13 +4248,26 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  commander@10.0.1: {}
+
   commander@13.1.0: {}
 
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
 
+  condense-newlines@0.2.1:
+    dependencies:
+      extend-shallow: 2.0.1
+      is-whitespace: 0.3.0
+      kind-of: 3.2.2
+
   confbox@0.1.8: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   consola@3.4.2: {}
 
@@ -4267,6 +4388,13 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.4:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.1
+      semver: 7.7.2
 
   electron-to-chromium@1.5.220: {}
 
@@ -4717,6 +4845,10 @@ snapshots:
 
   expect-type@1.2.2: {}
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   extendable-error@0.1.7: {}
 
   fast-deep-equal@3.1.3: {}
@@ -4963,6 +5095,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ini@1.3.8: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -4994,6 +5128,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-buffer@1.1.6: {}
+
   is-builtin-module@3.2.1:
     dependencies:
       builtin-modules: 3.3.0
@@ -5018,6 +5154,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -5102,6 +5240,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-whitespace@0.3.0: {}
+
   is-windows@1.0.2: {}
 
   isarray@2.0.5: {}
@@ -5126,6 +5266,16 @@ snapshots:
   javascript-natural-sort@0.7.1: {}
 
   joycon@3.1.1: {}
+
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.4
+      glob: 10.4.5
+      js-cookie: 3.0.5
+      nopt: 7.2.1
+
+  js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
 
@@ -5174,6 +5324,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@3.2.2:
+    dependencies:
+      is-buffer: 1.1.6
 
   language-subtag-registry@0.3.23: {}
 
@@ -5289,6 +5443,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@9.0.1:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
@@ -5330,6 +5488,10 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-releases@2.0.21: {}
+
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -5520,11 +5682,19 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  pretty@2.0.0:
+    dependencies:
+      condense-newlines: 0.2.1
+      extend-shallow: 2.0.1
+      js-beautify: 1.15.4
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proto-list@1.2.4: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## Summary

- Migrated `email-pretty` package from parcel repo to Customer.io monorepo as `@ciolabs/html-email-formatter`
- Converted from `ranges-apply` to `magic-string` for string manipulation
- Updated dependencies to use workspace packages for conditional comment handling
- Converted tests from snapshot-based to explicit assertions
- Fixed ESLint violations (`unicorn/prefer-string-slice`)

## Changes

### New Package: `@ciolabs/html-email-formatter`

Created new package with monorepo structure:
- `package.json` - Package configuration with workspace dependencies
- `src/index.ts` - Main email formatter implementation
- `src/index.test.ts` - Test suite with explicit assertions
- `tsconfig.json` - TypeScript configuration
- `tsup.config.ts` - Build configuration

### Key Implementation Changes

- **String manipulation**: Replaced `ranges-apply` with `magic-string` for better performance and workspace consistency
- **Dependencies**: Updated to use workspace packages:
  - `@ciolabs/html-find-conditional-comments` (was `find-conditional-comments`)
  - `@ciolabs/html-preserve-comment-whitespace` (was `preserve-comment-whitespace`)
- **Function name**: Renamed from `emailPretty` to `emailFormatter` for clarity
- **Logging**: Removed internal logger dependency (was `@internal/logger`)
- **Code style**: Fixed ESLint violations for string method preferences

### Functionality

The package provides HTML email formatting with special handling for:
- Conditional comments (MSO/Outlook compatibility)
- Whitespace preservation within comments
- Proper indentation alignment of open/close tags
- Full HTML formatting with configurable options