### PR TITLE
Migrate and convert html-mso-properties package

### DIFF
--- a/packages/html-mod/package.json
+++ b/packages/html-mod/package.json
@@ -40,7 +40,6 @@
     "magic-string": "^0.30.0"
   },
   "devDependencies": {
-    "@types/escape-html": "^1.0.0",
-    "@types/node": "^20.0.0"
+    "@types/escape-html": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Migrated `mso-properties` package from external repository to ciolabs monorepo
- Converted from JavaScript to TypeScript with proper type definitions
- Renamed to `html-mso-properties` to align with monorepo naming conventions
- Updated build process to use standard ciolabs tooling