### PR TITLE
add html-email-prettify package

### DIFF
--- a/.changeset/add-html-email-prettify.md
+++ b/.changeset/add-html-email-prettify.md
@@ -1,0 +1,5 @@
+---
+'@ciolabs/html-email-prettify': minor
+---
+
+add html-email-prettify package

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Open source libraries and configurations used at [Customer.io](https://customer.
 - [@ciolabs/config-prettier](./packages/config-prettier) - Shared Prettier configuration for Customer.io projects
 - [@ciolabs/framecast](./packages/framecast) - TypeScript cross-frame communication library
 - [@ciolabs/html-email-formatter](./packages/html-email-formatter) - Format and prettify HTML email content with conditional comment support
+- [@ciolabs/html-email-prettify](./packages/html-email-prettify) - AST-based email HTML formatter with email-safe whitespace handling
 - [@ciolabs/html-find-conditional-comments](./packages/html-find-conditional-comments) - Finds all conditional comments in a string
 - [@ciolabs/html-preserve-comment-whitespace](./packages/html-preserve-comment-whitespace) - Preserves the presence or lack thereof of whitespace surrounding HTML comments
 - [@ciolabs/html-process-conditional-comments](./packages/html-process-conditional-comments) - Makes it easy to safely process HTML inside of conditional comments

--- a/packages/html-email-prettify/README.md
+++ b/packages/html-email-prettify/README.md
@@ -2,7 +2,9 @@
 
 Format and prettify HTML email content with email-safe whitespace handling.
 
-Built on top of [`@ciolabs/html-mod`](../html-mod) — walks the AST and adjusts whitespace text nodes directly using position-tracked operations. No re-parse, no external formatting libraries. The `HtmlMod` instance stays live with valid positions throughout.
+Built on top of [`@ciolabs/html-mod`](../html-mod) — walks the AST and adjusts whitespace text nodes using position-tracked operations. No external formatting libraries. The returned `HtmlMod` has a fully consistent AST for further edits.
+
+**Note:** `prettify()` re-parses internally to sync the AST after formatting. Any `HtmlModElement` handles captured before calling `prettify(mod)` will be stale — re-query after formatting.
 
 ## Install
 
@@ -28,7 +30,8 @@ console.log(mod.toString());
 const doc = new HtmlMod('<div><p>original</p></div>');
 doc.querySelector('p').after('<table><tr><td>added</td></tr></table>');
 prettify(doc);
-// doc is now formatted with the new table properly indented
+// doc is now formatted — re-query elements after prettify
+const p = doc.querySelector('p');
 ```
 
 ## Options
@@ -39,13 +42,13 @@ prettify(input, {
   indentSize: 2, // default: 2
   indentChar: ' ', // default: ' ' (use '\t' for tabs)
 
-  // Line length & attribute wrapping
-  maxLineLength: 120, // default: 0 (off) — wrap attributes when tag exceeds this
+  // Attribute wrapping
+  maxLineLength: 120, // default: 0 (off) — triggers auto wrapping
   // default: 'auto'
   wrapAttributes:
     'auto' | //   wrap only when exceeding maxLineLength
-    'force' | //   always wrap, one attribute per line
-    'force-aligned' | //   always wrap, align to first attribute
+    'force' | //   always wrap, one attribute per line (no maxLineLength needed)
+    'force-aligned' | //   always wrap, align to first attribute (no maxLineLength needed)
     false, //   never wrap
 
   // Whitespace
@@ -55,7 +58,7 @@ prettify(input, {
 
 ## Attribute wrapping
 
-When `maxLineLength` is set and a tag's opening line exceeds it, attributes are broken onto new lines. Uses the "break before attribute" style which saves a character:
+Attributes are broken onto new lines using the "break before attribute" style, which saves a character:
 
 ```html
 <!-- Before -->
@@ -67,6 +70,8 @@ When `maxLineLength` is set and a tag's opening line exceeds it, attributes are 
   </table>
 </table>
 ```
+
+Tags that start mid-line (e.g. `<p>Hello <a href="...">`) are not wrapped — only tags at the start of a line.
 
 ## Email-specific whitespace rules
 

--- a/packages/html-email-prettify/README.md
+++ b/packages/html-email-prettify/README.md
@@ -35,21 +35,42 @@ prettify(doc);
 
 ```typescript
 prettify(input, {
-  indentSize: 4, // default: 2
-  indentChar: '\t', // default: ' '
+  // Indentation
+  indentSize: 2, // default: 2
+  indentChar: ' ', // default: ' ' (use '\t' for tabs)
+
+  // Line length & attribute wrapping
+  maxLineLength: 120, // default: 0 (off) — wrap attributes when tag exceeds this
+  // default: 'auto'
+  wrapAttributes:
+    'auto' | //   wrap only when exceeding maxLineLength
+    'force' | //   always wrap, one attribute per line
+    'force-aligned' | //   always wrap, align to first attribute
+    false, //   never wrap
+
+  // Whitespace
+  collapseBlankLines: true, // default: true — collapse 2+ blank lines to one
+
+  // Conditional comments
+  indentAfterConditionalComments: true, // default: true
+  // Set false to keep content at the same indent as the comment
 });
 ```
 
-## What it does
+## Attribute wrapping
 
-- Indents block elements with correct nesting depth
-- Leaves inline elements alone (no added gaps between `<span>`, `<a>`, `<img>`, `<font>`, etc.)
-- Preserves single-line conditional comments verbatim (MSO buttons, ghost tables)
-- Formats content inside multi-line conditional comments
-- Consistent indentation for closing-tag-only conditional comments
-- Protects downlevel-revealed bubble comments (`<!--[if !mso]><!-->...<!--<![endif]-->`)
-- Skips whitespace insertion between adjacent `display:inline-block` elements
-- Never touches `<pre>`, `<code>`, `<textarea>` content
+When `maxLineLength` is set and a tag's opening line exceeds it, attributes are broken onto new lines. Uses the "break before attribute" style which saves a character:
+
+```html
+<!-- Before -->
+<table cellpadding="0" cellspacing="0" border="0" width="600" align="center">
+  <!-- After (wrapAttributes: 'auto' or 'force') -->
+  <table cellpadding="0" cellspacing="0" border="0" width="600" align="center">
+    <!-- After (wrapAttributes: 'force-aligned') -->
+    <table cellpadding="0" cellspacing="0" border="0" width="600" align="center"></table>
+  </table>
+</table>
+```
 
 ## Email-specific whitespace rules
 
@@ -62,6 +83,7 @@ The formatter is aware of patterns where adding whitespace breaks email renderin
 | Single-line conditional comments | Content preserved verbatim                                   |
 | Bubble/revealed conditionals     | No whitespace inserted next to `<!--[if !mso]><!-->`         |
 | `<pre>`, `<code>`, `<textarea>`  | Internal content never touched                               |
+| NBSP (`\u00A0`)                  | Treated as semantic content, never stripped                  |
 
 ## License
 

--- a/packages/html-email-prettify/README.md
+++ b/packages/html-email-prettify/README.md
@@ -60,16 +60,26 @@ prettify(input, {
 
 Attributes are broken onto new lines using the "break before attribute" style, which saves a character:
 
-```html
-<!-- Before -->
-<table cellpadding="0" cellspacing="0" border="0" width="600" align="center">
-  <!-- After (wrapAttributes: 'auto' or 'force') -->
-  <table cellpadding="0" cellspacing="0" border="0" width="600" align="center">
-    <!-- After (wrapAttributes: 'force-aligned') -->
-    <table cellpadding="0" cellspacing="0" border="0" width="600" align="center"></table>
-  </table>
-</table>
-```
+Before:
+
+    <table cellpadding="0" cellspacing="0" border="0" width="600" align="center">
+
+After (`wrapAttributes: 'auto'` or `'force'`):
+
+    <table
+      cellpadding="0"
+      cellspacing="0"
+      border="0"
+      width="600"
+      align="center">
+
+After (`wrapAttributes: 'force-aligned'`):
+
+    <table cellpadding="0"
+           cellspacing="0"
+           border="0"
+           width="600"
+           align="center">
 
 Tags that start mid-line (e.g. `<p>Hello <a href="...">`) are not wrapped — only tags at the start of a line.
 

--- a/packages/html-email-prettify/README.md
+++ b/packages/html-email-prettify/README.md
@@ -1,0 +1,68 @@
+# @ciolabs/html-email-prettify
+
+Format and prettify HTML email content with email-safe whitespace handling.
+
+Built on top of [`@ciolabs/html-mod`](../html-mod) — walks the AST and adjusts whitespace text nodes directly using position-tracked operations. No re-parse, no external formatting libraries. The `HtmlMod` instance stays live with valid positions throughout.
+
+## Install
+
+```sh
+npm install @ciolabs/html-email-prettify
+```
+
+## Usage
+
+```typescript
+import prettify from '@ciolabs/html-email-prettify';
+import { HtmlMod } from '@ciolabs/html-mod';
+
+// From a string — returns a new HtmlMod
+const mod = prettify('<div><p>hello</p><p>world</p></div>');
+console.log(mod.toString());
+// <div>
+//   <p>hello</p>
+//   <p>world</p>
+// </div>
+
+// From an HtmlMod — mutates in place, returns the same instance
+const doc = new HtmlMod('<div><p>original</p></div>');
+doc.querySelector('p').after('<table><tr><td>added</td></tr></table>');
+prettify(doc);
+// doc is now formatted with the new table properly indented
+```
+
+## Options
+
+```typescript
+prettify(input, {
+  indentSize: 4, // default: 2
+  indentChar: '\t', // default: ' '
+});
+```
+
+## What it does
+
+- Indents block elements with correct nesting depth
+- Leaves inline elements alone (no added gaps between `<span>`, `<a>`, `<img>`, `<font>`, etc.)
+- Preserves single-line conditional comments verbatim (MSO buttons, ghost tables)
+- Formats content inside multi-line conditional comments
+- Consistent indentation for closing-tag-only conditional comments
+- Protects downlevel-revealed bubble comments (`<!--[if !mso]><!-->...<!--<![endif]-->`)
+- Skips whitespace insertion between adjacent `display:inline-block` elements
+- Never touches `<pre>`, `<code>`, `<textarea>` content
+
+## Email-specific whitespace rules
+
+The formatter is aware of patterns where adding whitespace breaks email rendering:
+
+| Pattern                          | Behavior                                                     |
+| -------------------------------- | ------------------------------------------------------------ |
+| Adjacent inline elements         | No whitespace added between `</span><span>`, `</a><a>`, etc. |
+| `display:inline-block` columns   | No whitespace added between adjacent inline-block elements   |
+| Single-line conditional comments | Content preserved verbatim                                   |
+| Bubble/revealed conditionals     | No whitespace inserted next to `<!--[if !mso]><!-->`         |
+| `<pre>`, `<code>`, `<textarea>`  | Internal content never touched                               |
+
+## License
+
+Apache-2.0 WITH Commons-Clause

--- a/packages/html-email-prettify/README.md
+++ b/packages/html-email-prettify/README.md
@@ -2,9 +2,9 @@
 
 Format and prettify HTML email content with email-safe whitespace handling.
 
-Built on top of [`@ciolabs/html-mod`](../html-mod) — walks the AST and adjusts whitespace text nodes using position-tracked operations. No external formatting libraries. The returned `HtmlMod` has a fully consistent AST for further edits.
+Built on top of [`@ciolabs/html-mod`](../html-mod) — walks the AST and adjusts whitespace text nodes using position-tracked operations. No external formatting libraries. The returned `HtmlMod` has a consistent AST for further edits.
 
-**Note:** `prettify()` re-parses internally to sync the AST after formatting. Any `HtmlModElement` handles captured before calling `prettify(mod)` will be stale — re-query after formatting.
+Most formatting operations are AST-aware (no re-parse). Attribute wrapping and blank-line collapse trigger a re-parse only when they make changes. `HtmlModElement` handles captured before `prettify(mod)` may be stale if those features are active — re-query after formatting.
 
 ## Install
 

--- a/packages/html-email-prettify/README.md
+++ b/packages/html-email-prettify/README.md
@@ -50,10 +50,6 @@ prettify(input, {
 
   // Whitespace
   collapseBlankLines: true, // default: true — collapse 2+ blank lines to one
-
-  // Conditional comments
-  indentAfterConditionalComments: true, // default: true
-  // Set false to keep content at the same indent as the comment
 });
 ```
 

--- a/packages/html-email-prettify/package.json
+++ b/packages/html-email-prettify/package.json
@@ -33,7 +33,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@ciolabs/html-find-conditional-comments": "workspace:*",
     "@ciolabs/html-mod": "workspace:*",
     "@ciolabs/htmlparser2-source": "workspace:*"
   }

--- a/packages/html-email-prettify/package.json
+++ b/packages/html-email-prettify/package.json
@@ -35,8 +35,6 @@
   "dependencies": {
     "@ciolabs/html-find-conditional-comments": "workspace:*",
     "@ciolabs/html-mod": "workspace:*",
-    "@ciolabs/html-process-conditional-comments": "workspace:*",
-    "@types/js-beautify": "^1.13.3",
-    "js-beautify": "~1.13.4"
+    "@ciolabs/htmlparser2-source": "workspace:*"
   }
 }

--- a/packages/html-email-prettify/package.json
+++ b/packages/html-email-prettify/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@ciolabs/html-email-prettify",
+  "version": "0.0.1",
+  "description": "Format and prettify HTML email content with email-safe whitespace handling",
+  "author": "Customer.io <win@customer.io>",
+  "license": "Apache-2.0 WITH Commons-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/customerio/ciolabs.git",
+    "directory": "packages/html-email-prettify"
+  },
+  "homepage": "https://github.com/customerio/ciolabs/tree/main/packages/html-email-prettify#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ciolabs/html-find-conditional-comments": "workspace:*",
+    "@ciolabs/html-mod": "workspace:*",
+    "@ciolabs/html-process-conditional-comments": "workspace:*",
+    "@types/js-beautify": "^1.13.3",
+    "js-beautify": "~1.13.4"
+  }
+}

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1339,6 +1339,16 @@ describe('collapseBlankLines + preserved content', () => {
     const result = prettify('<div><textarea>x\n\n\ny</textarea></div>');
     expect(result.__source).toContain('x\n\n\ny');
   });
+
+  test('does not collapse blank lines inside script', () => {
+    const result = prettify('<head><script>const x = `line1\n\n\nline2`;</script></head>');
+    expect(result.__source).toContain('line1\n\n\nline2');
+  });
+
+  test('does not collapse blank lines inside style', () => {
+    const result = prettify('<head><style>\n\n\n.foo { color: red; }\n\n\n</style></head>');
+    expect(result.__source).toContain('\n\n\n.foo');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1410,3 +1410,36 @@ describe('force wrap without maxLineLength', () => {
     expect(result.__source).toMatch(/\n\s+id="y"/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: wrap skips preserved element children
+// ---------------------------------------------------------------------------
+
+describe('attribute wrapping + preserved elements', () => {
+  test('does not wrap attributes inside pre', () => {
+    const result = prettify('<pre>\n<span class="long-class-name" style="color:red">x</span>\n</pre>', {
+      maxLineLength: 20,
+    });
+    // The span inside pre should NOT be wrapped
+    expect(result.__source).not.toContain('<span\n');
+    expect(result.__source).toContain('class="long-class-name"');
+  });
+
+  test('does not wrap attributes inside code', () => {
+    const result = prettify('<code><a href="x" class="y" style="z">link</a></code>', {
+      wrapAttributes: 'force',
+    });
+    expect(result.__source).not.toContain('<a\n');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: collapse skips pre inside conditional comments
+// ---------------------------------------------------------------------------
+
+describe('collapse + pre inside conditional comments', () => {
+  test('preserves blank lines in pre inside conditional comment', () => {
+    const result = format('<!--[if mso]>\n<pre>line1\n\n\nline2</pre>\n<![endif]-->');
+    expect(result).toContain('line1\n\n\nline2');
+  });
+});

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1,0 +1,767 @@
+import { HtmlMod } from '@ciolabs/html-mod';
+import { test, expect, describe } from 'vitest';
+
+import prettify from './index';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Get the formatted string from either HtmlMod or string input */
+function format(html: string): string {
+  const result = prettify(html);
+  return result.__source;
+}
+
+// ---------------------------------------------------------------------------
+// Basic formatting
+// ---------------------------------------------------------------------------
+
+describe('basic formatting', () => {
+  test('indents nested elements', () => {
+    const result = format('<div><p>hello</p></div>');
+    expect(result).toBe(
+      `<div>
+  <p>hello</p>
+</div>`
+    );
+  });
+
+  test('fixes inconsistent indentation', () => {
+    const result = format(`
+      <div>
+    <p>hello</p>
+          <span>world</span>
+      </div>
+    `);
+    expect(result).toBe(
+      `<div>
+  <p>hello</p>
+  <span>world</span>
+</div>`
+    );
+  });
+
+  test('handles empty input', () => {
+    const result = format('');
+    expect(result).toBe('');
+  });
+
+  test('preserves self-closing tags', () => {
+    const result = format('<div><br/><img src="test.png"/></div>');
+    // js-beautify normalizes self-closing tags to have a space before />
+    expect(result).toBe(`<div><br /><img src="test.png" /></div>`);
+  });
+
+  test('formats a full HTML document', () => {
+    const result = format(
+      `<!DOCTYPE html><html><head><title>Test</title></head><body><div><p>hello</p></div></body></html>`
+    );
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('<html>');
+    expect(result).toContain('</html>');
+    // Content should be indented
+    expect(result).toMatch(/\s+<p>hello<\/p>/);
+  });
+
+  test('preserves attributes', () => {
+    const result = format('<div class="foo" id="bar" style="color: red;"><p>hello</p></div>');
+    expect(result).toContain('class="foo"');
+    expect(result).toContain('id="bar"');
+    expect(result).toContain('style="color: red;"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre/code preservation
+// ---------------------------------------------------------------------------
+
+describe('pre and code preservation', () => {
+  test('preserves whitespace inside <pre> tags', () => {
+    const result = format(
+      `<div><pre>  line 1
+    line 2
+      line 3</pre></div>`
+    );
+    expect(result).toContain(
+      `<pre>  line 1
+    line 2
+      line 3</pre>`
+    );
+  });
+
+  test('preserves whitespace inside <code> tags', () => {
+    const result = format(`<div><code>  function() { return true; }  </code></div>`);
+    expect(result).toContain('  function() { return true; }  ');
+  });
+
+  test('preserves whitespace inside <textarea> tags', () => {
+    const result = format(
+      `<div><textarea>  some
+    preformatted
+      text  </textarea></div>`
+    );
+    expect(result).toContain(
+      `<textarea>  some
+    preformatted
+      text  </textarea>`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conditional comments — single-line
+// ---------------------------------------------------------------------------
+
+describe('single-line conditional comments', () => {
+  test('preserves single-line conditional comment content', () => {
+    const result = format(
+      `<div><!--[if mso]><table cellpadding="0" cellspacing="0" border="0"><tr><td><![endif]--></div>`
+    );
+    expect(result).toContain('<!--[if mso]><table cellpadding="0" cellspacing="0" border="0"><tr><td><![endif]-->');
+  });
+
+  test('preserves single-line conditional comment when it has no content', () => {
+    const result = format(`<div><!--[if mso]><![endif]--></div>`);
+    expect(result).toContain('<!--[if mso]><![endif]-->');
+  });
+
+  test("preserves Mark's link button pattern", () => {
+    const input = `<a href="https://parcel.io" style="background-color:#005959; text-decoration: none; padding: .5em 2em; color: #FCFDFF; display:inline-block; border-radius:.4em; mso-padding-alt:0;text-underline-color:#005959"><!--[if mso]><i style="mso-font-width:200%;mso-text-raise:100%" hidden>&emsp;</i><span style="mso-text-raise:50%;"><![endif]-->My link text<!--[if mso]></span><i style="mso-font-width:200%;" hidden>&emsp;&#8203;</i><![endif]--></a>`;
+
+    const result = format(input);
+
+    // Both conditional comments should remain single-line with original content
+    expect(result).toContain(
+      '<!--[if mso]><i style="mso-font-width:200%;mso-text-raise:100%" hidden>&emsp;</i><span style="mso-text-raise:50%;"><![endif]-->'
+    );
+    expect(result).toContain(
+      '<!--[if mso]></span><i style="mso-font-width:200%;" hidden>&emsp;&#8203;</i><![endif]-->'
+    );
+  });
+
+  test('preserves paired ghost table conditional comments', () => {
+    const result = format(`<div>
+  <!--[if mso]><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td style="background-color: rgb(255, 255, 255);"><![endif]-->
+  <p>Content</p>
+  <!--[if mso]></td></tr></table><![endif]-->
+</div>`);
+
+    expect(result).toContain(
+      '<!--[if mso]><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td style="background-color: rgb(255, 255, 255);"><![endif]-->'
+    );
+    expect(result).toContain('<!--[if mso]></td></tr></table><![endif]-->');
+  });
+
+  test('keeps no whitespace if there was none', () => {
+    const result = format('<div><!--[if MAC]>hello<![endif]--></div>');
+    expect(result).toContain('<!--[if MAC]>hello<![endif]-->');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conditional comments — multi-line
+// ---------------------------------------------------------------------------
+
+describe('multi-line conditional comments', () => {
+  test('formats content inside multi-line conditional comments', () => {
+    const result = format(`<div>
+<!--[if mso]>
+<table cellpadding="0" cellspacing="0">
+<tr>
+<td>Content</td>
+</tr>
+</table>
+<![endif]-->
+</div>`);
+
+    // The content inside should be indented
+    expect(result).toContain('<!--[if mso]>');
+    expect(result).toContain('<![endif]-->');
+    expect(result).toContain('<table');
+    expect(result).toContain('</table>');
+  });
+
+  test('aligns open and close tags of multi-line conditional comments', () => {
+    const result = format(`
+    <div>
+    <!--[if MAC]>
+    <div>
+    <span>
+    <![endif]-->
+    <!--[if MAC]>
+    </span>
+    </div>
+    <![endif]-->
+    </div>
+  `);
+
+    const lines = result.split('\n');
+
+    // Find lines with conditional comment open/close tags
+    for (const line of lines) {
+      if (line.includes('<!--[if MAC]>')) {
+        // Find the matching close
+        const openIndent = line.match(/^(\s*)/)?.[1] ?? '';
+        const closeLineIndex = lines.indexOf(
+          lines.find((l, index) => index > lines.indexOf(line) && l.includes('<![endif]-->'))!
+        );
+        if (closeLineIndex >= 0) {
+          const closeIndent = lines[closeLineIndex].match(/^(\s*)/)?.[1] ?? '';
+          expect(openIndent).toBe(closeIndent);
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inline element whitespace preservation
+// ---------------------------------------------------------------------------
+
+describe('inline element whitespace', () => {
+  test('does not add whitespace between adjacent inline elements', () => {
+    const result = format('<div><span>a</span><span>b</span></div>');
+    expect(result).toContain('<span>a</span><span>b</span>');
+  });
+
+  test('does not add whitespace between adjacent img elements', () => {
+    const result = format('<div><img src="a.png"/><img src="b.png"/></div>');
+    // js-beautify normalizes space before />, but no whitespace between tags
+    expect(result).toContain('<img src="a.png" /><img src="b.png" />');
+  });
+
+  test('does not add whitespace between adjacent anchor elements', () => {
+    const result = format('<div><a href="#">link1</a><a href="#">link2</a></div>');
+    expect(result).toContain('<a href="#">link1</a><a href="#">link2</a>');
+  });
+
+  test('preserves space between inline elements when it exists', () => {
+    const result = format('<div><span>a</span> <span>b</span></div>');
+    // The space between the spans should be preserved
+    expect(result).toMatch(/<span>a<\/span>\s+<span>b<\/span>/);
+  });
+
+  test('does not add whitespace between mixed inline elements', () => {
+    const result = format('<div><strong>bold</strong><em>italic</em><span>text</span></div>');
+    expect(result).toContain('<strong>bold</strong><em>italic</em><span>text</span>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Table adjacency
+// ---------------------------------------------------------------------------
+
+describe('table element formatting', () => {
+  test('formats table structure with proper indentation', () => {
+    const result = format('<table><tr><td>cell1</td><td>cell2</td></tr></table>');
+    expect(result).toContain('<table>');
+    expect(result).toContain('</table>');
+    expect(result).toContain('<td>cell1</td>');
+    expect(result).toContain('<td>cell2</td>');
+  });
+
+  test('handles nested tables', () => {
+    const result = format('<table><tr><td><table><tr><td>inner</td></tr></table></td></tr></table>');
+    expect(result).toContain('inner');
+    // Should have some indentation structure
+    const lines = result.split('\n');
+    expect(lines.length).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ghost table pattern
+// ---------------------------------------------------------------------------
+
+describe('ghost table patterns', () => {
+  test('formats a complete ghost table layout', () => {
+    const result =
+      format(`<!--[if mso]><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td><![endif]-->
+<div style="max-width: 600px; margin: 0 auto;">
+<p>Content here</p>
+</div>
+<!--[if mso]></td></tr></table><![endif]-->`);
+
+    // Single-line conditional comments should be preserved
+    expect(result).toContain('<!--[if mso]>');
+    expect(result).toContain('<![endif]-->');
+    // Content should be formatted
+    expect(result).toContain('<p>Content here</p>');
+  });
+
+  test('handles multiple ghost table columns', () => {
+    const result = format(`<!--[if true]>
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0">
+<tr>
+<td width="300">
+<![endif]-->
+<div style="display:inline-block; width:300px;">
+Column 1
+</div>
+<!--[if true]>
+</td>
+<td width="300">
+<![endif]-->
+<div style="display:inline-block; width:300px;">
+Column 2
+</div>
+<!--[if true]>
+</td>
+</tr>
+</table>
+<![endif]-->`);
+
+    expect(result).toContain('Column 1');
+    expect(result).toContain('Column 2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HtmlMod integration
+// ---------------------------------------------------------------------------
+
+describe('HtmlMod integration', () => {
+  test('accepts a string and returns HtmlMod', () => {
+    const result = prettify('<div><p>hello</p></div>');
+    expect(result).toBeInstanceOf(HtmlMod);
+    expect(result.__source).toContain('<div>');
+  });
+
+  test('accepts HtmlMod and returns the same instance', () => {
+    const mod = new HtmlMod('<div><p>hello</p></div>');
+    const result = prettify(mod);
+    expect(result).toBe(mod); // Same reference
+  });
+
+  test('mutates HtmlMod source in place', () => {
+    const mod = new HtmlMod('  <div><p>hello</p></div>  ');
+    prettify(mod);
+    // Source should be updated
+    expect(mod.__source).not.toBe('  <div><p>hello</p></div>  ');
+  });
+
+  test('returned HtmlMod can be queried', () => {
+    const result = prettify('<div class="test"><p>hello</p></div>');
+    const div = result.querySelector('.test');
+    expect(div).not.toBeNull();
+    expect(div!.innerHTML).toContain('<p>hello</p>');
+  });
+
+  test('returned HtmlMod can be modified after formatting', () => {
+    const result = prettify('<div><p>hello</p></div>');
+    const p = result.querySelector('p');
+    expect(p).not.toBeNull();
+    p!.textContent = 'world';
+    expect(result.__source).toContain('world');
+  });
+
+  test('HtmlMod modifications followed by prettify', () => {
+    const mod = new HtmlMod('<div><p>hello</p></div>');
+    const p = mod.querySelector('p')!;
+    p.after('<span>added</span>');
+
+    prettify(mod);
+
+    expect(mod.__source).toContain('<p>hello</p>');
+    expect(mod.__source).toContain('<span>added</span>');
+    // Should be properly formatted
+    const lines = mod.__source.split('\n');
+    expect(lines.length).toBeGreaterThan(1);
+  });
+
+  test('preserves HtmlMod options', () => {
+    const mod = new HtmlMod('<div />', { recognizeSelfClosing: true });
+    prettify(mod);
+    expect(mod.__options.recognizeSelfClosing).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-world email patterns
+// ---------------------------------------------------------------------------
+
+describe('real-world email patterns', () => {
+  test('formats a typical email structure', () => {
+    const result = format(`<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Email</title><style>body { margin: 0; }</style></head><body><table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td align="center"><table role="presentation" width="600" cellpadding="0" cellspacing="0"><tr><td><h1>Hello!</h1><p>This is an email.</p></td></tr></table></td></tr></table></body></html>`);
+
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('<h1>Hello!</h1>');
+    expect(result).toContain('<p>This is an email.</p>');
+    // Should have meaningful indentation
+    const lines = result.split('\n');
+    expect(lines.length).toBeGreaterThan(5);
+  });
+
+  test('formats email with MSO conditional head styles', () => {
+    const result = format(`<!DOCTYPE html>
+<html>
+<head>
+<!--[if mso]>
+<style>
+.button { padding: 10px; }
+</style>
+<![endif]-->
+</head>
+<body>
+<p>Hello</p>
+</body>
+</html>`);
+
+    expect(result).toContain('<!--[if mso]>');
+    expect(result).toContain('<![endif]-->');
+    expect(result).toContain('<p>Hello</p>');
+  });
+
+  test('handles Outlook button with VML-style padding', () => {
+    const input = `<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="padding: 20px;">
+<a href="https://example.com" style="background:#005959;text-decoration:none;padding:.5em 2em;color:#FCFDFF;display:inline-block;border-radius:.4em;mso-padding-alt:0;text-underline-color:#005959"><!--[if mso]><i style="mso-font-width:200%;mso-text-raise:100%" hidden>&emsp;</i><span style="mso-text-raise:50%;"><![endif]-->Click Here<!--[if mso]></span><i style="mso-font-width:200%;" hidden>&emsp;&#8203;</i><![endif]--></a>
+</td></tr></table>`;
+
+    const result = format(input);
+
+    // The button pattern MUST stay intact — whitespace here breaks Outlook
+    expect(result).toContain(
+      '<!--[if mso]><i style="mso-font-width:200%;mso-text-raise:100%" hidden>&emsp;</i><span style="mso-text-raise:50%;"><![endif]-->'
+    );
+    expect(result).toContain(
+      '<!--[if mso]></span><i style="mso-font-width:200%;" hidden>&emsp;&#8203;</i><![endif]-->'
+    );
+  });
+
+  test('preserves inline whitespace in single-line conditional comments', () => {
+    const result = format('<div> <!--[if MAC]> hello    <![endif]-->      </div>');
+    expect(result).toContain('<!--[if MAC]> hello    <![endif]-->');
+  });
+
+  test('handles downlevel-revealed (negated) conditional comments', () => {
+    const result = format(`<!--[if !mso]><!--><div>Non-Outlook content</div><!--<![endif]-->`);
+    // Bubble/revealed comments should pass through
+    expect(result).toContain('Non-Outlook content');
+  });
+
+  test('formats from existing tests: properly format from a single line', () => {
+    const result = format(`<!DOCTYPE html>
+  <html style="">
+
+    <body class="">
+
+      <!--[if mso]><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td style="background-color: rgb(255, 255, 255);"><![endif]-->
+
+      <!--[if mso]></td></tr></table><![endif]-->
+
+       </body>
+  </html>`);
+
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('</html>');
+    // Single-line conditional comments should be preserved
+    expect(result).toContain(
+      '<!--[if mso]><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td style="background-color: rgb(255, 255, 255);"><![endif]-->'
+    );
+    expect(result).toContain('<!--[if mso]></td></tr></table><![endif]-->');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Options pass-through
+// ---------------------------------------------------------------------------
+
+describe('options', () => {
+  test('respects custom indent_size', () => {
+    // eslint-disable-next-line camelcase
+    const result = prettify('<div><p>hello</p></div>', { indent_size: 4 });
+    expect(result.__source).toContain('    <p>hello</p>');
+  });
+
+  test('respects custom indent_char', () => {
+    const result = prettify('<div><p>hello</p></div>', {
+      indent_size: 1, // eslint-disable-line camelcase
+      indent_char: '\t', // eslint-disable-line camelcase
+    });
+    expect(result.__source).toContain('\t<p>hello</p>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('edge cases', () => {
+  test('handles multiple conditional comments on the same line', () => {
+    const result = format('<!--[if mso]><table><![endif]--><!--[if mso]></table><![endif]-->');
+    expect(result).toContain('<!--[if mso]><table><![endif]-->');
+    expect(result).toContain('<!--[if mso]></table><![endif]-->');
+  });
+
+  test('handles nested conditional comments', () => {
+    const result = format(`<!--[if mso]>
+<table>
+<!--[if gte mso 9]>
+<tr><td>inner</td></tr>
+<![endif]-->
+</table>
+<![endif]-->`);
+
+    expect(result).toContain('<!--[if mso]>');
+    expect(result).toContain('<!--[if gte mso 9]>');
+    expect(result).toContain('<![endif]-->');
+  });
+
+  test('handles conditional comments with no content', () => {
+    const result = format('<div><!--[if mso]><![endif]--></div>');
+    expect(result).toContain('<!--[if mso]><![endif]-->');
+  });
+
+  test('handles deeply nested HTML', () => {
+    const result = format('<div><div><div><div><div><p>deep</p></div></div></div></div></div>');
+    expect(result).toContain('deep');
+    const lines = result.split('\n');
+    expect(lines.length).toBeGreaterThan(5);
+  });
+
+  test('does not crash on malformed HTML', () => {
+    const result = format('<div><p>unclosed');
+    expect(result).toContain('unclosed');
+  });
+
+  test('handles empty conditional comment between content', () => {
+    const result = format('<p>before</p><!--[if mso]><![endif]--><p>after</p>');
+    expect(result).toContain('before');
+    expect(result).toContain('after');
+    expect(result).toContain('<!--[if mso]><![endif]-->');
+  });
+
+  test('handles HTML with only whitespace', () => {
+    const result = format('   \n\n   ');
+    expect(result.trim()).toBe('');
+  });
+
+  test('handles single element', () => {
+    const result = format('<br/>');
+    expect(result).toContain('<br');
+  });
+
+  test('handles comment-only HTML', () => {
+    const result = format('<!-- just a comment -->');
+    expect(result).toContain('<!-- just a comment -->');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency
+// ---------------------------------------------------------------------------
+
+describe('idempotency', () => {
+  test('formatting twice produces the same result', () => {
+    const input = `<div>
+      <p>hello</p>
+        <span>world</span>
+    </div>`;
+
+    const first = format(input);
+    const second = format(first);
+    expect(second).toBe(first);
+  });
+
+  test('formatting a well-formatted document is a no-op', () => {
+    const input = `<div>
+  <p>hello</p>
+  <span>world</span>
+</div>`;
+
+    const result = format(input);
+    expect(result).toBe(input);
+  });
+
+  test('idempotent with conditional comments', () => {
+    const input = `<div>
+  <!--[if mso]><table><tr><td><![endif]-->
+  <p>Content</p>
+  <!--[if mso]></td></tr></table><![endif]-->
+</div>`;
+
+    const first = format(input);
+    const second = format(first);
+    expect(second).toBe(first);
+  });
+
+  test("idempotent with Mark's button pattern", () => {
+    const input = `<a href="https://parcel.io" style="background:#005959;text-decoration:none;padding:.5em 2em;color:#FCFDFF;display:inline-block"><!--[if mso]><i style="mso-font-width:200%;mso-text-raise:100%" hidden>&emsp;</i><span style="mso-text-raise:50%;"><![endif]-->Click<!--[if mso]></span><i style="mso-font-width:200%;" hidden>&emsp;&#8203;</i><![endif]--></a>`;
+
+    const first = format(input);
+    const second = format(first);
+    expect(second).toBe(first);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple sequential edits + format
+// ---------------------------------------------------------------------------
+
+describe('edit then format workflow', () => {
+  test('format after adding elements', () => {
+    const mod = new HtmlMod('<div><p>original</p></div>');
+    const p = mod.querySelector('p')!;
+    p.after('<p>added1</p><p>added2</p>');
+
+    prettify(mod);
+
+    const source = mod.__source;
+    expect(source).toContain('<p>original</p>');
+    expect(source).toContain('<p>added1</p>');
+    expect(source).toContain('<p>added2</p>');
+
+    // All p tags should be at the same indentation level
+    const lines = source.split('\n');
+    const pLines = lines.filter(l => l.trim().startsWith('<p>'));
+    const indents = pLines.map(l => l.match(/^(\s*)/)?.[1]?.length ?? 0);
+    expect(new Set(indents).size).toBe(1);
+  });
+
+  test('format after removing elements', () => {
+    const mod = new HtmlMod(`<div>
+  <p>keep</p>
+  <p>remove</p>
+  <p>keep too</p>
+</div>`);
+    const toRemove = mod.querySelectorAll('p')[1];
+    toRemove.remove();
+
+    prettify(mod);
+
+    expect(mod.__source).toContain('<p>keep</p>');
+    expect(mod.__source).not.toContain('remove');
+    expect(mod.__source).toContain('<p>keep too</p>');
+  });
+
+  test('format after changing innerHTML', () => {
+    const mod = new HtmlMod('<div><p>old</p></div>');
+    const div = mod.querySelector('div')!;
+    div.innerHTML = '<table><tr><td>cell1</td><td>cell2</td></tr></table>';
+
+    prettify(mod);
+
+    expect(mod.__source).toContain('<table>');
+    expect(mod.__source).toContain('cell1');
+    expect(mod.__source).toContain('cell2');
+    // Should be formatted, not all on one line
+    const lines = mod.__source.split('\n');
+    expect(lines.length).toBeGreaterThan(1);
+  });
+
+  test('format after setAttribute', () => {
+    const mod = new HtmlMod('<div><p>text</p></div>');
+    const p = mod.querySelector('p')!;
+    p.setAttribute('class', 'highlight');
+    p.setAttribute('style', 'color: red;');
+
+    prettify(mod);
+
+    expect(mod.__source).toContain('class="highlight"');
+    expect(mod.__source).toContain('style="color: red;"');
+  });
+
+  test('multiple format calls on same HtmlMod', () => {
+    const mod = new HtmlMod('<div><p>hello</p></div>');
+
+    // First format
+    prettify(mod);
+    const after1 = mod.__source;
+
+    // Add content
+    mod.querySelector('p')!.after('<p>world</p>');
+
+    // Second format
+    prettify(mod);
+    const after2 = mod.__source;
+
+    expect(after2).toContain('<p>hello</p>');
+    expect(after2).toContain('<p>world</p>');
+    expect(after2).not.toBe(after1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitespace-sensitive email patterns (deeper coverage)
+// ---------------------------------------------------------------------------
+
+describe('whitespace-sensitive email patterns', () => {
+  test('inline-block columns with no gap', () => {
+    // This is the #1 email whitespace issue — space between inline-block
+    // elements causes columns to stack on iOS/Android
+    const result = format(
+      '<div style="font-size:0;"><div style="display:inline-block;width:50%;">Col 1</div><div style="display:inline-block;width:50%;">Col 2</div></div>'
+    );
+    // The inner divs should not have whitespace added between them
+    // (they're block elements so js-beautify will likely put them on separate lines,
+    // which is a known limitation — the user's code intentionally has no gap)
+    expect(result).toContain('Col 1');
+    expect(result).toContain('Col 2');
+  });
+
+  test('adjacent spans in button text', () => {
+    const result = format(
+      '<a href="#"><span style="color:white;">Click</span><span style="color:white;"> Here</span></a>'
+    );
+    // Inline elements should stay adjacent
+    expect(result).toContain('<span style="color:white;">Click</span><span style="color:white;"> Here</span>');
+  });
+
+  test('conditional comment between text content', () => {
+    const result = format('<td>Before<!--[if mso]>&nbsp;<![endif]-->After</td>');
+    expect(result).toContain('<!--[if mso]>&nbsp;<![endif]-->');
+  });
+
+  test('multiple single-line conditional comments in email', () => {
+    const result = format(`<body>
+<!--[if mso]><table width="600"><tr><td><![endif]-->
+<div style="max-width:600px;">
+  <h1>Title</h1>
+  <a href="#"><!--[if mso]><i hidden>&emsp;</i><span><![endif]-->Button<!--[if mso]></span><i hidden>&emsp;</i><![endif]--></a>
+</div>
+<!--[if mso]></td></tr></table><![endif]-->
+</body>`);
+
+    // All 4 single-line conditional comments should be preserved
+    expect(result).toContain('<!--[if mso]><table width="600"><tr><td><![endif]-->');
+    expect(result).toContain('<!--[if mso]></td></tr></table><![endif]-->');
+    expect(result).toContain('<!--[if mso]><i hidden>&emsp;</i><span><![endif]-->');
+    expect(result).toContain('<!--[if mso]></span><i hidden>&emsp;</i><![endif]-->');
+  });
+
+  test('preserves comment with HTML entities in content', () => {
+    const result = format('<div><!--[if mso]><i hidden>&emsp;&nbsp;&#8203;</i><![endif]--></div>');
+    expect(result).toContain('<!--[if mso]><i hidden>&emsp;&nbsp;&#8203;</i><![endif]-->');
+  });
+
+  test('conditional comment wrapping an entire table structure', () => {
+    const result = format(`<!--[if mso]>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" align="center">
+<tr>
+<td>
+<![endif]-->
+<div style="max-width: 600px; margin: 0 auto;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+<tr>
+<td style="padding: 20px;">
+<h1>Hello World</h1>
+<p>This is an email body.</p>
+</td>
+</tr>
+</table>
+</div>
+<!--[if mso]>
+</td>
+</tr>
+</table>
+<![endif]-->`);
+
+    // Multi-line conditional comments should be formatted
+    expect(result).toContain('<!--[if mso]>');
+    expect(result).toContain('<![endif]-->');
+    expect(result).toContain('<h1>Hello World</h1>');
+    expect(result).toContain('<p>This is an email body.</p>');
+  });
+});

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1178,3 +1178,39 @@ describe('input type detection', () => {
     expect(result).toBe(mod);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: uppercase STYLE attribute with inline-block
+// ---------------------------------------------------------------------------
+
+describe('uppercase STYLE attribute', () => {
+  test('inline-block columns with uppercase STYLE stay adjacent (no text node)', () => {
+    const mod = new HtmlMod(
+      '<div><div STYLE="display:inline-block">A</div><div STYLE="display:inline-block">B</div></div>',
+      { lowerCaseAttributeNames: false }
+    );
+    prettify(mod);
+    expect(mod.__source).toContain('</div><div STYLE="display:inline-block">B</div>');
+  });
+
+  test('inline-block columns with uppercase STYLE stay adjacent (whitespace text node)', () => {
+    const mod = new HtmlMod(
+      '<div><div STYLE="display:inline-block">A</div> <div STYLE="display:inline-block">B</div></div>',
+      { lowerCaseAttributeNames: false }
+    );
+    prettify(mod);
+    // The space between should NOT become a newline
+    expect(mod.__source).not.toMatch(/<\/div>\n\s*<div STYLE="display:inline-block">B/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: NBSP inside multi-line conditional comments
+// ---------------------------------------------------------------------------
+
+describe('NBSP in conditional comments', () => {
+  test('NBSP inside multi-line conditional is preserved', () => {
+    const result = format('<!--[if mso]>\n\u00A0<span>x</span>\n<![endif]-->');
+    expect(result).toContain('\u00A0');
+  });
+});

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -697,6 +697,13 @@ describe('whitespace-sensitive email patterns', () => {
     expect(result).toContain('</div><div style="display:inline-block;width:50%;">Col 2</div>');
   });
 
+  test('inline-block div next to block element gets separated', () => {
+    const result = format('<td><div style="display:inline-block;">A</div><p>B</p></td>');
+    // The p is not inline-block, so whitespace should be inserted
+    expect(result).toContain('</div>\n');
+    expect(result).toContain('<p>B</p>');
+  });
+
   test('adjacent regular divs get separated', () => {
     const result = format('<td><div>A</div><div>B</div></td>');
     expect(result).toContain('<div>A</div>\n');

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -697,6 +697,16 @@ describe('whitespace-sensitive email patterns', () => {
     expect(result).toContain('</div><div style="display:inline-block;width:50%;">Col 2</div>');
   });
 
+  test('inline-block columns with existing whitespace text node stay adjacent', () => {
+    // Already-formatted source with a space between inline-block elements.
+    // The formatter must not expand this to a newline + indent.
+    const result = format(
+      '<div style="font-size:0;"><div style="display:inline-block;width:50%;">Col 1</div> <div style="display:inline-block;width:50%;">Col 2</div></div>'
+    );
+    // Should NOT have a newline between the two inline-block divs
+    expect(result).not.toMatch(/<\/div>\n\s*<div style="display:inline-block;width:50%;">Col 2/);
+  });
+
   test('inline-block div next to block element gets separated', () => {
     const result = format('<td><div style="display:inline-block;">A</div><p>B</p></td>');
     // The p is not inline-block, so whitespace should be inserted
@@ -996,6 +1006,21 @@ describe('downlevel-revealed conditional comments', () => {
     // The space between <p>A</p> and <p>B</p> must survive — it's inside
     // a single-line bubble conditional.
     expect(result).toContain('<p>A</p> <p>B</p>');
+  });
+
+  test('two bubble conditionals in same sibling list: gap between them is formatted', () => {
+    // Two separate revealed conditionals with a block element between them.
+    // The whitespace between the first close and second open should NOT
+    // be protected — it's outside both conditionals.
+    const result = format(
+      '<div><!--[if !mso]><!--><span>A</span><!--<![endif]--><p>middle</p><!--[if !mso]><!--><span>B</span><!--<![endif]--></div>'
+    );
+
+    // Content inside each conditional is preserved
+    expect(result).toContain('<span>A</span>');
+    expect(result).toContain('<span>B</span>');
+    // The <p> between them should be on its own line (formatted)
+    expect(result).toMatch(/\n\s+<p>middle<\/p>/);
   });
 });
 

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -985,4 +985,42 @@ describe('downlevel-revealed conditional comments', () => {
     expect(result).toContain('<!--<![endif]-->');
     expect(result).toContain('<span>web only</span>');
   });
+
+  test('stale ranges: bubble conditional after formatted content stays protected', () => {
+    // Repro: formatting compact tables BEFORE a bubble conditional shifts
+    // positions.  The bubble conditional content must still be protected.
+    const result = format(
+      '<div><table><tr><td>cell</td></tr></table></div><!--[if !mso]><!--><p>A</p> <p>B</p><!--<![endif]-->'
+    );
+
+    // The space between <p>A</p> and <p>B</p> must survive — it's inside
+    // a single-line bubble conditional.
+    expect(result).toContain('<p>A</p> <p>B</p>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: legacy inline elements
+// ---------------------------------------------------------------------------
+
+describe('legacy inline elements', () => {
+  test('font tags stay adjacent', () => {
+    const result = format('<p><font>A</font><font>B</font></p>');
+    expect(result).toContain('<font>A</font><font>B</font>');
+  });
+
+  test('strike tags stay adjacent', () => {
+    const result = format('<p><strike>old</strike><b>new</b></p>');
+    expect(result).toContain('<strike>old</strike><b>new</b>');
+  });
+
+  test('big and tt tags stay inline', () => {
+    const result = format('<p><big>large</big><tt>mono</tt></p>');
+    expect(result).toContain('<big>large</big><tt>mono</tt>');
+  });
+
+  test('wbr stays inline', () => {
+    const result = format('<p>longword<wbr/>here</p>');
+    expect(result).toContain('longword<wbr/>here');
+  });
 });

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -531,6 +531,18 @@ describe('options', () => {
     expect(result.__source).toMatch(/\n\s+border="0"/);
   });
 
+  test('AST is consistent after force wrapping — edits work', () => {
+    const mod = prettify('<div class="x" id="y"><p>hello</p></div>', {
+      wrapAttributes: 'force',
+    });
+    const p = mod.querySelector('p');
+    expect(p).not.toBeNull();
+    expect(p!.textContent).toBe('hello');
+    p!.textContent = 'world';
+    expect(mod.__source).toContain('world');
+    expect(mod.__source).not.toContain('hello');
+  });
+
   test('wrapAttributes false: never wraps', () => {
     const result = prettify('<p class="intro" style="color: red; font-size: 16px;" id="main">hello</p>', {
       maxLineLength: 20,

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1022,6 +1022,18 @@ describe('downlevel-revealed conditional comments', () => {
     // The <p> between them should be on its own line (formatted)
     expect(result).toMatch(/\n\s+<p>middle<\/p>/);
   });
+
+  test('single-line bubble does not protect later multi-line bubble', () => {
+    // First conditional is single-line, second is multi-line.
+    // The multi-line one's <p> should still be indented.
+    const result = format(
+      '<div><!--[if !mso]><!--><span>A</span><!--<![endif]--><!--[if !mso]><!-->\n<p>B</p>\n<!--<![endif]--></div>'
+    );
+
+    expect(result).toContain('<span>A</span>');
+    // The <p>B</p> inside the multi-line conditional should be formatted
+    expect(result).toMatch(/\n\s+<p>B<\/p>/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1117,6 +1129,12 @@ describe('NBSP preservation', () => {
     // Regular whitespace is formatting — should be normalized
     expect(result).toContain('<p>hello</p>\n');
     expect(result).toContain('<p>world</p>');
+  });
+
+  test('NBSP at document boundaries is preserved', () => {
+    const result = format('\u00A0<div><p>x</p></div>\u00A0');
+    expect(result.startsWith('\u00A0')).toBe(true);
+    expect(result.endsWith('\u00A0')).toBe(true);
   });
 });
 

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -250,6 +250,12 @@ describe('inline element whitespace', () => {
     const result = format('<div><p>x</p><span>a</span><span>b</span></div>');
     expect(result).toContain('<span>a</span><span>b</span>');
   });
+
+  test('whitespace text node between inline siblings is preserved', () => {
+    const result = format('<div><p>x</p><span>a</span>   <span>b</span></div>');
+    // The spaces between spans should not become a newline+indent
+    expect(result).not.toMatch(/<span>a<\/span>\n\s+<span>b<\/span>/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -547,6 +553,12 @@ describe('options', () => {
     prettify(mod, { collapseBlankLines: false });
     // The triple newline inside <p> content should survive
     expect(mod.__source).toContain('\n\n\n');
+  });
+
+  test('collapseBlankLines: collapses indented blank lines', () => {
+    const result = prettify('<div>\n  \n  \n  <p>hello</p>\n  \n  \n</div>');
+    // Indented blank lines should be collapsed too
+    expect(result.__source).not.toMatch(/(?:\n[\t ]*){2}\n/);
   });
 });
 
@@ -1404,6 +1416,17 @@ describe('attribute wrapping safety', () => {
 // ---------------------------------------------------------------------------
 // Regression: attribute wrapping + pre preservation
 // ---------------------------------------------------------------------------
+
+describe('attribute wrapping inside conditional comments', () => {
+  test('force wraps attributes inside multi-line conditional comments', () => {
+    const result = prettify(
+      '<!--[if mso]>\n<table cellpadding="0" cellspacing="0" border="0" width="600"><tr><td>x</td></tr></table>\n<![endif]-->',
+      { wrapAttributes: 'force' }
+    );
+    // The table inside the conditional should have wrapped attributes
+    expect(result.__source).toContain('<table\n');
+  });
+});
 
 describe('attribute wrapping + pre content', () => {
   test('blank lines inside pre survive when wrapping shifts positions', () => {

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1095,3 +1095,68 @@ describe('DOCTYPE formatting', () => {
     expect(result).toContain('<!DOCTYPE html>');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: NBSP and Unicode spaces
+// ---------------------------------------------------------------------------
+
+describe('NBSP preservation', () => {
+  test('NBSP between block elements is not treated as formatting whitespace', () => {
+    const result = format('<td><p>A</p>\u00A0<p>B</p></td>');
+    expect(result).toContain('\u00A0');
+  });
+
+  test('NBSP text node is not replaced with indentation', () => {
+    const result = format('<div><p>hello</p>\u00A0<p>world</p></div>');
+    // The NBSP should survive — it's content, not formatting
+    expect(result).toContain('\u00A0');
+  });
+
+  test('regular whitespace between blocks is still normalized', () => {
+    const result = format('<div><p>hello</p>   \n   <p>world</p></div>');
+    // Regular whitespace is formatting — should be normalized
+    expect(result).toContain('<p>hello</p>\n');
+    expect(result).toContain('<p>world</p>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: case-insensitive tag names
+// ---------------------------------------------------------------------------
+
+describe('uppercase tag names', () => {
+  test('uppercase inline elements stay adjacent', () => {
+    const mod = new HtmlMod('<p><SPAN>A</SPAN><SPAN>B</SPAN></p>', { lowerCaseTags: false });
+    prettify(mod);
+    expect(mod.__source).toContain('<SPAN>A</SPAN><SPAN>B</SPAN>');
+  });
+
+  test('uppercase block elements get formatted', () => {
+    const mod = new HtmlMod('<DIV><P>hello</P></DIV>', { lowerCaseTags: false });
+    prettify(mod);
+    expect(mod.__source).toContain('\n');
+  });
+
+  test('uppercase pre content is preserved', () => {
+    const mod = new HtmlMod('<DIV><PRE>  preserved  </PRE></DIV>', { lowerCaseTags: false });
+    prettify(mod);
+    expect(mod.__source).toContain('  preserved  ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: string vs HtmlMod input detection
+// ---------------------------------------------------------------------------
+
+describe('input type detection', () => {
+  test('string input returns HtmlMod', () => {
+    const result = prettify('<div><p>hello</p></div>');
+    expect(result.__source).toBeDefined();
+  });
+
+  test('HtmlMod input returns same instance', () => {
+    const mod = new HtmlMod('<div><p>hello</p></div>');
+    const result = prettify(mod);
+    expect(result).toBe(mod);
+  });
+});

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -245,6 +245,11 @@ describe('inline element whitespace', () => {
     const result = format('<div><strong>bold</strong><em>italic</em><span>text</span></div>');
     expect(result).toContain('<strong>bold</strong><em>italic</em><span>text</span>');
   });
+
+  test('adjacent inline elements stay together even with block siblings', () => {
+    const result = format('<div><p>x</p><span>a</span><span>b</span></div>');
+    expect(result).toContain('<span>a</span><span>b</span>');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1277,3 +1277,75 @@ describe('NBSP in conditional comments', () => {
     expect(result).toContain('\u00A0');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: AST sync after formatting
+// ---------------------------------------------------------------------------
+
+describe('AST consistency', () => {
+  test('querySelector returns consistent innerHTML after formatting', () => {
+    const mod = prettify('<div><!--x--><p>a</p></div>');
+    const div = mod.querySelector('div');
+    expect(div).not.toBeNull();
+    // The innerHTML should match what's between <div> and </div> in __source
+    const divMatch = /<div>([\S\s]*)<\/div>/.exec(mod.__source);
+    expect(divMatch).not.toBeNull();
+    expect(div!.innerHTML).toBe(divMatch![1]);
+  });
+
+  test('querySelector works correctly after formatting', () => {
+    const mod = prettify('<div><p class="test">hello</p></div>');
+    const p = mod.querySelector('p');
+    expect(p).not.toBeNull();
+    expect(p!.getAttribute('class')).toBe('test');
+    expect(p!.innerHTML).toBe('hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: collapseBlankLines preserves pre/code/textarea
+// ---------------------------------------------------------------------------
+
+describe('collapseBlankLines + preserved content', () => {
+  test('does not collapse blank lines inside pre', () => {
+    const result = prettify('<div><pre>line1\n\n\nline2</pre></div>');
+    expect(result.__source).toContain('line1\n\n\nline2');
+  });
+
+  test('does not collapse blank lines inside code', () => {
+    const result = prettify('<div><code>a\n\n\nb</code></div>');
+    expect(result.__source).toContain('a\n\n\nb');
+  });
+
+  test('does not collapse blank lines inside textarea', () => {
+    const result = prettify('<div><textarea>x\n\n\ny</textarea></div>');
+    expect(result.__source).toContain('x\n\n\ny');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: attribute wrapping doesn't corrupt comments
+// ---------------------------------------------------------------------------
+
+describe('attribute wrapping safety', () => {
+  test('does not wrap attributes inside conditional comments', () => {
+    const result = prettify(
+      '<!--[if mso]><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td><![endif]-->',
+      { maxLineLength: 40 }
+    );
+    // The conditional comment content should remain intact
+    expect(result.__source).toContain(
+      '<!--[if mso]><table cellpadding="0" cellspacing="0" border="0" width="100%"><tr><td><![endif]-->'
+    );
+  });
+
+  test('does not corrupt inline text when wrapping nearby element', () => {
+    const result = prettify(
+      '<div><p>Hello <a href="https://example.com" style="color: red; text-decoration: none; font-weight: bold;">link</a></p></div>',
+      { maxLineLength: 40 }
+    );
+    // The <p>Hello text should not appear on attribute lines
+    expect(result.__source).toContain('Hello');
+    expect(result.__source).toContain('link</a>');
+  });
+});

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -480,6 +480,69 @@ describe('options', () => {
     });
     expect(result.__source).toContain('\t<p>hello</p>');
   });
+
+  test('maxLineLength + wrapAttributes auto: wraps long tags', () => {
+    const result = prettify(
+      '<div><p class="intro" style="color: red; font-size: 16px; line-height: 1.5;" id="main">hello</p></div>',
+      { maxLineLength: 40 }
+    );
+    // Attributes should be wrapped onto separate lines
+    expect(result.__source).toContain('<p\n');
+    expect(result.__source).toMatch(/class="intro"/);
+    expect(result.__source).toMatch(/style="color: red/);
+    expect(result.__source).toMatch(/id="main"/);
+  });
+
+  test('maxLineLength: short tags are not wrapped', () => {
+    const result = prettify('<div><p class="x">hello</p></div>', {
+      maxLineLength: 80,
+    });
+    // Short tag stays on one line
+    expect(result.__source).toContain('<p class="x">hello</p>');
+  });
+
+  test('wrapAttributes force: always wraps even short tags', () => {
+    const result = prettify('<div><p class="x" id="y">hello</p></div>', {
+      maxLineLength: 200,
+      wrapAttributes: 'force',
+    });
+    expect(result.__source).toContain('<p\n');
+  });
+
+  test('wrapAttributes force-aligned: aligns to first attribute', () => {
+    const result = prettify('<table cellpadding="0" cellspacing="0" border="0"><tr><td>x</td></tr></table>', {
+      maxLineLength: 40,
+      wrapAttributes: 'force-aligned',
+    });
+    // First attribute on same line as tag, subsequent aligned
+    expect(result.__source).toMatch(/<table cellpadding="0"/);
+    expect(result.__source).toMatch(/\n\s+cellspacing="0"/);
+    expect(result.__source).toMatch(/\n\s+border="0"/);
+  });
+
+  test('wrapAttributes false: never wraps', () => {
+    const result = prettify('<p class="intro" style="color: red; font-size: 16px;" id="main">hello</p>', {
+      maxLineLength: 20,
+      wrapAttributes: false,
+    });
+    // Should stay on one line despite exceeding maxLineLength
+    expect(result.__source).not.toContain('<p\n');
+  });
+
+  test('collapseBlankLines: multiple blank lines become one', () => {
+    const result = prettify('<div>\n\n\n\n<p>hello</p>\n\n\n\n<p>world</p>\n\n\n\n</div>');
+    // No runs of 3+ newlines
+    expect(result.__source).not.toMatch(/\n{3,}/);
+  });
+
+  test('collapseBlankLines false: does not collapse blank lines', () => {
+    // Use a pre-formatted string where blank lines are already part of
+    // inline content that the formatter doesn't touch
+    const mod = new HtmlMod('<p>line 1\n\n\nline 2</p>');
+    prettify(mod, { collapseBlankLines: false });
+    // The triple newline inside <p> content should survive
+    expect(mod.__source).toContain('\n\n\n');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -49,8 +49,8 @@ describe('basic formatting', () => {
 
   test('preserves self-closing tags', () => {
     const result = format('<div><br/><img src="test.png"/></div>');
-    // js-beautify normalizes self-closing tags to have a space before />
-    expect(result).toBe(`<div><br /><img src="test.png" /></div>`);
+    // AST-based formatter preserves original self-closing syntax
+    expect(result).toBe(`<div><br/><img src="test.png"/></div>`);
   });
 
   test('formats a full HTML document', () => {
@@ -227,8 +227,7 @@ describe('inline element whitespace', () => {
 
   test('does not add whitespace between adjacent img elements', () => {
     const result = format('<div><img src="a.png"/><img src="b.png"/></div>');
-    // js-beautify normalizes space before />, but no whitespace between tags
-    expect(result).toContain('<img src="a.png" /><img src="b.png" />');
+    expect(result).toContain('<img src="a.png"/><img src="b.png"/>');
   });
 
   test('does not add whitespace between adjacent anchor elements', () => {
@@ -469,16 +468,15 @@ describe('real-world email patterns', () => {
 // ---------------------------------------------------------------------------
 
 describe('options', () => {
-  test('respects custom indent_size', () => {
-    // eslint-disable-next-line camelcase
-    const result = prettify('<div><p>hello</p></div>', { indent_size: 4 });
+  test('respects custom indentSize', () => {
+    const result = prettify('<div><p>hello</p></div>', { indentSize: 4 });
     expect(result.__source).toContain('    <p>hello</p>');
   });
 
-  test('respects custom indent_char', () => {
+  test('respects custom indentChar', () => {
     const result = prettify('<div><p>hello</p></div>', {
-      indent_size: 1, // eslint-disable-line camelcase
-      indent_char: '\t', // eslint-disable-line camelcase
+      indentSize: 1,
+      indentChar: '\t',
     });
     expect(result.__source).toContain('\t<p>hello</p>');
   });

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1374,3 +1374,39 @@ describe('attribute wrapping + pre content', () => {
     expect(result.__source).toContain('line1\n\n\nline2');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: multi-line conditional comment double-shift
+// ---------------------------------------------------------------------------
+
+describe('conditional comment position tracking', () => {
+  test('content after multi-line conditional is properly formatted', () => {
+    const result = format(
+      '<body><!--[if mso]>\n<table><tr><td>x</td></tr></table>\n<![endif]--><div>after</div></body>'
+    );
+    // The <div> should be on its own line, not glued to <![endif]-->
+    expect(result).toMatch(/<!\[endif]-->\n/);
+    expect(result).toContain('<div>after</div>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: force wrap without maxLineLength
+// ---------------------------------------------------------------------------
+
+describe('force wrap without maxLineLength', () => {
+  test('wrapAttributes force works without maxLineLength', () => {
+    const result = prettify('<p class="x" id="y">hello</p>', {
+      wrapAttributes: 'force',
+    });
+    expect(result.__source).toContain('<p\n');
+  });
+
+  test('wrapAttributes force-aligned works without maxLineLength', () => {
+    const result = prettify('<p class="x" id="y">hello</p>', {
+      wrapAttributes: 'force-aligned',
+    });
+    expect(result.__source).toMatch(/<p class="x"/);
+    expect(result.__source).toMatch(/\n\s+id="y"/);
+  });
+});

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -688,15 +688,13 @@ describe('edit then format workflow', () => {
 describe('whitespace-sensitive email patterns', () => {
   test('inline-block columns with no gap', () => {
     // This is the #1 email whitespace issue — space between inline-block
-    // elements causes columns to stack on iOS/Android
+    // elements causes columns to stack on iOS/Android.
+    // When two elements are directly adjacent (no whitespace text node),
+    // the formatter must NOT insert whitespace between them.
     const result = format(
       '<div style="font-size:0;"><div style="display:inline-block;width:50%;">Col 1</div><div style="display:inline-block;width:50%;">Col 2</div></div>'
     );
-    // The inner divs should not have whitespace added between them
-    // (they're block elements so js-beautify will likely put them on separate lines,
-    // which is a known limitation — the user's code intentionally has no gap)
-    expect(result).toContain('Col 1');
-    expect(result).toContain('Col 2');
+    expect(result).toContain('</div><div style="display:inline-block;width:50%;">Col 2</div>');
   });
 
   test('adjacent spans in button text', () => {
@@ -813,5 +811,62 @@ describe('whitespace-sensitive email patterns', () => {
     expect(result).toContain('<![endif]-->');
     expect(result).toContain('<h1>Hello World</h1>');
     expect(result).toContain('<p>This is an email body.</p>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: multi-line conditional comment followed by content
+// ---------------------------------------------------------------------------
+
+describe('multi-line conditional comment AST integrity', () => {
+  test('comment ranges do not bleed into following elements', () => {
+    const mod = prettify('<!--[if mso]>\n<table><tr><td>x</td></tr></table>\n<![endif]--><div><p>after</p></div>');
+
+    // The <div> should be queryable and its positions correct
+    const div = mod.querySelector('div');
+    expect(div).not.toBeNull();
+    expect(div!.innerHTML).toContain('<p>after</p>');
+    expect(div!.outerHTML).toContain('<div>');
+
+    // The <p> inside should also be valid
+    const paragraph = mod.querySelector('p');
+    expect(paragraph).not.toBeNull();
+    expect(paragraph!.textContent).toBe('after');
+  });
+
+  test('further edits after formatting multi-line comments stay valid', () => {
+    const mod = prettify('<!--[if mso]>\n<table><tr><td>x</td></tr></table>\n<![endif]--><div><p>after</p></div>');
+
+    // Modify content after the conditional comment
+    const paragraph = mod.querySelector('p')!;
+    paragraph.textContent = 'changed';
+
+    expect(mod.__source).toContain('changed');
+    expect(mod.__source).toContain('<![endif]-->');
+    // The change should not corrupt the conditional comment
+    expect(mod.__source).not.toContain('changed</td>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: preserved elements treated as block for sibling formatting
+// ---------------------------------------------------------------------------
+
+describe('preserved element sibling formatting', () => {
+  test('pre inside div gets indentation around it', () => {
+    const result = format('<div><pre>  line1\n  line2</pre></div>');
+    expect(result).toBe(`<div>\n  <pre>  line1\n  line2</pre>\n</div>`);
+  });
+
+  test('textarea inside div gets indentation around it', () => {
+    const result = format('<div><textarea>content</textarea></div>');
+    expect(result).toBe(`<div>\n  <textarea>content</textarea>\n</div>`);
+  });
+
+  test('pre alongside other elements gets formatted correctly', () => {
+    const result = format('<div><p>before</p><pre>  preserved  </pre><p>after</p></div>');
+    expect(result).toContain('  <p>before</p>');
+    expect(result).toContain('  <pre>  preserved  </pre>');
+    expect(result).toContain('  <p>after</p>');
   });
 });

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -697,6 +697,15 @@ describe('whitespace-sensitive email patterns', () => {
     expect(result).toContain('</div><div style="display:inline-block;width:50%;">Col 2</div>');
   });
 
+  test('adjacent regular divs get separated', () => {
+    const result = format('<td><div>A</div><div>B</div></td>');
+    expect(result).toContain('<div>A</div>\n');
+    expect(result).toContain('<div>B</div>');
+    // Both divs should be on separate lines
+    const lines = result.split('\n').filter(l => l.includes('<div>'));
+    expect(lines.length).toBe(2);
+  });
+
   test('adjacent spans in button text', () => {
     const result = format(
       '<a href="#"><span style="color:white;">Click</span><span style="color:white;"> Here</span></a>'

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1344,8 +1344,33 @@ describe('attribute wrapping safety', () => {
       '<div><p>Hello <a href="https://example.com" style="color: red; text-decoration: none; font-weight: bold;">link</a></p></div>',
       { maxLineLength: 40 }
     );
-    // The <p>Hello text should not appear on attribute lines
+    // Inline <a> starts mid-line — should not be wrapped
     expect(result.__source).toContain('Hello');
     expect(result.__source).toContain('link</a>');
+    // No corrupted lines with "<p>Hello" as indent
+    expect(result.__source).not.toMatch(/<p>Hello\s+href=/);
+  });
+
+  test('mid-line inline tag is not wrapped', () => {
+    const result = prettify('<p>Hello <a href="https://example.com" style="color: red;">link</a></p>', {
+      maxLineLength: 20,
+    });
+    // The <a> starts after "Hello " — not at line start, so skip wrapping
+    expect(result.__source).not.toContain('<a\n');
+    expect(result.__source).toContain('Hello <a');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: attribute wrapping + pre preservation
+// ---------------------------------------------------------------------------
+
+describe('attribute wrapping + pre content', () => {
+  test('blank lines inside pre survive when wrapping shifts positions', () => {
+    const result = prettify(
+      '<div><p class="long-class-name" style="color: red; font-size: 16px;">x</p><pre>line1\n\n\nline2</pre></div>',
+      { maxLineLength: 40 }
+    );
+    expect(result.__source).toContain('line1\n\n\nline2');
   });
 });

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -939,4 +939,50 @@ describe('multi-line conditional comment as only child', () => {
     expect(result).toContain('<![endif]-->');
     expect(result).toContain('<div>content</div>');
   });
+
+  test('multi-line conditional with closing tags only gets consistent indentation', () => {
+    const result = format(`<div>
+<!--[if mso]>
+</td>
+</tr>
+</table>
+<![endif]-->
+</div>`);
+
+    // Each closing tag line should have the same indentation
+    const lines = result.split('\n');
+    const closingTagLines = lines.filter(l => /^\s*<\/(?:td|tr|table)>/.test(l));
+    expect(closingTagLines.length).toBe(3);
+    const indents = closingTagLines.map(l => l.match(/^(\s*)/)?.[1] ?? '');
+    // All closing tags should have consistent indentation
+    expect(new Set(indents).size).toBe(1);
+    // And it should be indented (not at column 0)
+    expect(indents[0].length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: downlevel-revealed conditional comments
+// ---------------------------------------------------------------------------
+
+describe('downlevel-revealed conditional comments', () => {
+  test('does not insert whitespace inside single-line revealed conditional', () => {
+    const result = format(
+      '<!--[if !mso]><!--><div style="display:inline-block">A</div><div style="display:inline-block">B</div><!--<![endif]-->'
+    );
+
+    // The inline-block divs should stay adjacent
+    expect(result).toContain('</div><div style="display:inline-block">B</div>');
+    // No whitespace between the comments and the content
+    expect(result).toContain('<!--><div style="display:inline-block">A</div>');
+    expect(result).toContain('</div><!--<![endif]-->');
+  });
+
+  test('preserves revealed conditional with inline content', () => {
+    const result = format('<td><!--[if !mso]><!--><span>web only</span><!--<![endif]--></td>');
+
+    expect(result).toContain('<!--[if !mso]><!-->');
+    expect(result).toContain('<!--<![endif]-->');
+    expect(result).toContain('<span>web only</span>');
+  });
 });

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1300,6 +1300,24 @@ describe('AST consistency', () => {
     expect(p!.getAttribute('class')).toBe('test');
     expect(p!.innerHTML).toBe('hello');
   });
+
+  test('textContent reflects collapsed blank lines', () => {
+    const mod = prettify('<p>a\n\n\nb</p>');
+    const p = mod.querySelector('p');
+    expect(p).not.toBeNull();
+    // After collapse, the triple newline becomes double
+    expect(p!.textContent).toBe('a\n\nb');
+  });
+
+  test('no phantom text nodes after trailing whitespace trim', () => {
+    const mod = prettify('<div>x</div>   ');
+    // Source should be trimmed
+    expect(mod.__source).toBe('<div>x</div>');
+    // Should be queryable
+    const div = mod.querySelector('div');
+    expect(div).not.toBeNull();
+    expect(div!.innerHTML).toBe('x');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -886,3 +886,57 @@ describe('preserved element sibling formatting', () => {
     expect(result).toContain('  <p>after</p>');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: multi-line conditional comment as only child
+// ---------------------------------------------------------------------------
+
+describe('multi-line conditional comment as only child', () => {
+  test('formats content inside comment when it is the only child', () => {
+    const result = format(`<div>
+<!--[if mso]>
+<table><tr><td>x</td></tr></table>
+<![endif]-->
+</div>`);
+
+    // The comment's inner content should be formatted
+    expect(result).toContain('<table>');
+    expect(result).toContain('<tr>');
+    expect(result).toContain('<td>x</td>');
+    // Inner content should have proper indentation (not left-aligned)
+    const lines = result.split('\n');
+    const tableLine = lines.find(l => l.includes('<table>'));
+    expect(tableLine).toBeDefined();
+    expect(tableLine!.startsWith(' ')).toBe(true);
+  });
+
+  test('multi-line conditional comment inner content has consistent indentation', () => {
+    const result = format('<!--[if mso]>\n<table><tr><td>x</td></tr></table>\n<![endif]-->');
+
+    // Should produce clean indentation, not ragged
+    expect(result).toContain('<table>');
+    expect(result).toContain('</table>');
+    // The table content should be indented relative to the table
+    expect(result).toMatch(/<tr>\s*\n\s+<td>/);
+  });
+
+  test('multi-line conditional with nested tables formats cleanly', () => {
+    const result = format(`<body>
+<!--[if mso]>
+<table cellpadding="0" cellspacing="0" border="0" width="600">
+<tr>
+<td>
+<![endif]-->
+<div>content</div>
+<!--[if mso]>
+</td>
+</tr>
+</table>
+<![endif]-->
+</body>`);
+
+    expect(result).toContain('<!--[if mso]>');
+    expect(result).toContain('<![endif]-->');
+    expect(result).toContain('<div>content</div>');
+  });
+});

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -1091,6 +1091,13 @@ describe('downlevel-revealed conditional comments', () => {
     expect(result).toMatch(/\n\s+<p>middle<\/p>/);
   });
 
+  test('spaced revealed conditional is also protected', () => {
+    // <!--[if !mso]><!-- --> with a space before --> is a valid variant
+    const result = format('<!--[if !mso]><!-- --><span>A</span><!-- <![endif]-->');
+    // Content should stay adjacent to comments
+    expect(result).toContain('--><span>A</span><!--');
+  });
+
   test('single-line bubble does not protect later multi-line bubble', () => {
     // First conditional is single-line, second is multi-line.
     // The multi-line one's <p> should still be indented.

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -57,8 +57,8 @@ describe('basic formatting', () => {
     const result = format(
       `<!DOCTYPE html><html><head><title>Test</title></head><body><div><p>hello</p></div></body></html>`
     );
-    expect(result).toContain('<!DOCTYPE html>');
-    expect(result).toContain('<html>');
+    // DOCTYPE and html should be on separate lines
+    expect(result).toMatch(/<!DOCTYPE html>\n<html>/);
     expect(result).toContain('</html>');
     // Content should be indented
     expect(result).toMatch(/\s+<p>hello<\/p>/);
@@ -1022,5 +1022,51 @@ describe('legacy inline elements', () => {
   test('wbr stays inline', () => {
     const result = format('<p>longword<wbr/>here</p>');
     expect(result).toContain('longword<wbr/>here');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: case-insensitive conditional comments
+// ---------------------------------------------------------------------------
+
+describe('case-insensitive conditional comments', () => {
+  test('uppercase IF is recognized as multi-line conditional', () => {
+    const result = format(`<!--[IF mso]>
+<table><tr><td>x</td></tr></table>
+<![endif]-->`);
+
+    expect(result).toContain('<table>');
+    expect(result).toContain('<tr>');
+    expect(result).toContain('<td>x</td>');
+  });
+
+  test('mixed case conditional comment gets formatted', () => {
+    const result = format(`<div>
+<!--[IF MSO]>
+<table><tr><td>content</td></tr></table>
+<![ENDIF]-->
+</div>`);
+
+    expect(result).toContain('<!--[IF MSO]>');
+    expect(result).toContain('<![ENDIF]-->');
+    expect(result).toContain('<table>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: DOCTYPE directive formatting
+// ---------------------------------------------------------------------------
+
+describe('DOCTYPE formatting', () => {
+  test('html tag goes on its own line after DOCTYPE', () => {
+    const result = format('<!DOCTYPE html><html><body><p>hi</p></body></html>');
+    const lines = result.split('\n');
+    expect(lines[0]).toBe('<!DOCTYPE html>');
+    expect(lines[1]).toBe('<html>');
+  });
+
+  test('DOCTYPE is preserved exactly', () => {
+    const result = format('<!DOCTYPE html><html><body></body></html>');
+    expect(result).toContain('<!DOCTYPE html>');
   });
 });

--- a/packages/html-email-prettify/src/index.test.ts
+++ b/packages/html-email-prettify/src/index.test.ts
@@ -734,6 +734,58 @@ describe('whitespace-sensitive email patterns', () => {
     expect(result).toContain('<!--[if mso]><i hidden>&emsp;&nbsp;&#8203;</i><![endif]-->');
   });
 
+  test('adjacent block elements with no whitespace between them', () => {
+    const result = format('<div><p>hello</p><p>world</p></div>');
+    expect(result).toBe(`<div>\n  <p>hello</p>\n  <p>world</p>\n</div>`);
+  });
+
+  test('ghost table open/close in separate comments with compact content', () => {
+    const result = format(
+      '<!--[if mso]><table><tr><td><![endif]--><div><p>hello</p><p>world</p></div><!--[if mso]></td></tr></table><![endif]-->'
+    );
+
+    // Single-line conditional comments preserved
+    expect(result).toContain('<!--[if mso]><table><tr><td><![endif]-->');
+    expect(result).toContain('<!--[if mso]></td></tr></table><![endif]-->');
+    // Content between them is formatted
+    expect(result).toContain('<div>');
+    expect(result).toContain('  <p>hello</p>');
+    expect(result).toContain('  <p>world</p>');
+    expect(result).toContain('</div>');
+    // Comments are on their own lines, not glued to content
+    const lines = result.split('\n');
+    expect(lines[0].trim()).toBe('<!--[if mso]><table><tr><td><![endif]-->');
+    expect(lines.at(-1)!.trim()).toBe('<!--[if mso]></td></tr></table><![endif]-->');
+  });
+
+  test('ghost table with messy table content gets formatted', () => {
+    const result = format(
+      '<!--[if mso]><table><tr><td><![endif]-->\n<div><table><tr><td>cell1</td><td>cell2</td></tr><tr><td>cell3</td><td>cell4</td></tr></table></div>\n<!--[if mso]></td></tr></table><![endif]-->'
+    );
+
+    // Table inside should be properly indented
+    expect(result).toContain('  <table>');
+    expect(result).toContain('      <td>cell1</td>');
+    expect(result).toContain('      <td>cell3</td>');
+  });
+
+  test('html-mod insertion between ghost table comments gets formatted', () => {
+    const mod = new HtmlMod(
+      '<div><!--[if mso]><table><tr><td><![endif]--><p>original</p><!--[if mso]></td></tr></table><![endif]--></div>'
+    );
+    mod.querySelector('p')!.after('<table><tr><td>inserted</td></tr></table>');
+
+    prettify(mod);
+
+    expect(mod.__source).toContain('<p>original</p>');
+    expect(mod.__source).toContain('<td>inserted</td>');
+    // The inserted table should be properly indented
+    expect(mod.__source).toContain('  <table>');
+    // Both conditional comments preserved
+    expect(mod.__source).toContain('<!--[if mso]><table><tr><td><![endif]-->');
+    expect(mod.__source).toContain('<!--[if mso]></td></tr></table><![endif]-->');
+  });
+
   test('conditional comment wrapping an entire table structure', () => {
     const result = format(`<!--[if mso]>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" align="center">

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -5,35 +5,51 @@ import { isComment, isTag, isText } from '@ciolabs/htmlparser2-source';
 
 /**
  * Inline HTML elements — we never add newlines around these.
+ * Includes legacy/deprecated tags still common in email HTML.
  */
 const INLINE_ELEMENTS = new Set([
   'a',
   'abbr',
+  'acronym',
   'b',
+  'bdi',
   'bdo',
+  'big',
   'br',
+  'button',
   'cite',
   'code',
+  'data',
   'del',
   'dfn',
   'em',
+  'font',
   'i',
   'img',
+  'input',
   'ins',
   'kbd',
   'label',
   'mark',
+  'meter',
+  'output',
+  'progress',
   'q',
+  'ruby',
   's',
   'samp',
+  'select',
   'small',
   'span',
+  'strike',
   'strong',
   'sub',
   'sup',
   'time',
+  'tt',
   'u',
   'var',
+  'wbr',
 ]);
 
 /**
@@ -62,26 +78,13 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
   const mod = input instanceof HtmlMod ? input : new HtmlMod(input);
   const indent = (options?.indentChar ?? ' ').repeat(options?.indentSize ?? 2);
 
-  // Build a set of character ranges for single-line conditional comments.
-  // We must not touch whitespace inside these.
-  const singleLineRanges = buildSingleLineConditionalRanges(mod.__source);
-
-  // Build a set of comment data strings that belong to single-line
-  // bubble/revealed conditional comments.  These are the patterns
-  // like <!--[if !mso]><!-->...<!--<![endif]--> where inserting
-  // whitespace next to the comments would break inline-block layouts.
-  const singleLineBubbleCommentData = buildSingleLineBubbleCommentData(mod.__source);
+  // Collect comment data strings for single-line bubble/revealed
+  // conditionals.  Position-independent — survives formatting mutations.
+  const bubbleCommentData = buildSingleLineBubbleCommentData(mod.__source);
 
   // Format the document tree.
   // Depth -1 so that top-level elements sit at indent 0.
-  formatChildren(
-    mod,
-    mod.__dom.children as Iterable<SourceElement | SourceText>,
-    -1,
-    indent,
-    singleLineRanges,
-    singleLineBubbleCommentData
-  );
+  formatChildren(mod, mod.__dom.children as Iterable<SourceElement | SourceText>, -1, indent, bubbleCommentData);
 
   // Trim trailing whitespace on the document
   mod.trimEnd();
@@ -105,8 +108,7 @@ function formatChildren(
   children: Iterable<SourceElement | SourceText>,
   depth: number,
   indent: string,
-  singleLineRanges: Array<[number, number]>,
-  singleLineBubbleCommentData?: Set<string>
+  bubbleCommentData: Set<string>
 ): void {
   const childArray = [...children];
 
@@ -121,6 +123,12 @@ function formatChildren(
 
   if (!hasBlock) return;
 
+  // Check if any sibling is a bubble comment — if so, text nodes between
+  // bubble comment pairs are protected (position-independent check).
+  const hasBubbleSibling = childArray.some(
+    child => isComment(child) && bubbleCommentData.has((child as { data?: string }).data ?? '')
+  );
+
   const childIndent = indent.repeat(Math.max(0, depth + 1));
   const parentIndent = indent.repeat(Math.max(0, depth));
 
@@ -133,9 +141,14 @@ function formatChildren(
     // --- Whitespace text nodes between siblings --------------------------
     // In a block context, normalize whitespace-only text nodes to the
     // correct indentation regardless of what follows (block or inline).
+    // Skip text nodes that sit between bubble comment pairs — those are
+    // inside a single-line conditional and must not be touched.
     if (isText(child)) {
       const textNode = child as SourceText;
-      if (isWhitespaceOnly(textNode.data) && !isInsideSingleLineConditional(textNode, singleLineRanges)) {
+      if (
+        isWhitespaceOnly(textNode.data) &&
+        !(hasBubbleSibling && isTextBetweenBubbleComments(index, childArray, bubbleCommentData))
+      ) {
         setTextContent(mod, textNode, `\n${isLast ? parentIndent : childIndent}`);
       }
       continue;
@@ -153,7 +166,7 @@ function formatChildren(
       previous &&
       !isText(previous) &&
       !(hasInlineBlockStyle(previous) && hasInlineBlockStyle(child)) &&
-      !isBubbleCommentBoundary(previous, child, singleLineBubbleCommentData)
+      !isBubbleCommentBoundary(previous, child, bubbleCommentData)
     ) {
       // Two non-text nodes directly adjacent — insert whitespace between
       // them.  Skip when:
@@ -186,8 +199,7 @@ function formatChildren(
           element.children as Iterable<SourceElement | SourceText>,
           depth + 1,
           indent,
-          singleLineRanges,
-          singleLineBubbleCommentData
+          bubbleCommentData
         );
       }
 
@@ -206,7 +218,7 @@ function formatChildren(
 
       // Format inside multi-line conditional comments
       if (isMultiLineConditional(child)) {
-        formatInsideConditionalComment(mod, child, depth + 1, indent, singleLineRanges);
+        formatInsideConditionalComment(mod, child, depth + 1, indent);
       }
     }
   }
@@ -227,8 +239,7 @@ function formatInsideConditionalComment(
   mod: HtmlMod,
   commentNode: { startIndex: number; endIndex: number; data: string },
   depth: number,
-  indent: string,
-  _singleLineRanges: Array<[number, number]>
+  indent: string
 ): void {
   const { data, startIndex, endIndex } = commentNode;
 
@@ -248,13 +259,13 @@ function formatInsideConditionalComment(
   // inner content should be indented at `depth` level (matching where
   // the comment sits in the outer document).
   const innerMod = new HtmlMod(trimmedInnerHtml);
-  const innerSingleLineRanges = buildSingleLineConditionalRanges(trimmedInnerHtml);
+  const innerBubbleData = buildSingleLineBubbleCommentData(trimmedInnerHtml);
   formatChildren(
     innerMod,
     innerMod.__dom.children as Iterable<SourceElement | SourceText>,
     depth - 1,
     indent,
-    innerSingleLineRanges
+    innerBubbleData
   );
 
   // Align the close tag (<![endif]) with the open tag (<!--[if).
@@ -292,11 +303,6 @@ function formatInsideConditionalComment(
   const delta = newLength - oldLength;
 
   // Shift sibling nodes BEFORE touching the comment itself.
-  // shiftPositionsAfter uses `endIndex + 1` as boundary — at this point
-  // commentNode.endIndex is still the original value, so the walk won't
-  // match the comment in the `startIndex >= afterPos` branch and can
-  // only hit the `endIndex >= afterPos` branch.  But we're about to
-  // set endIndex ourselves, so shift first to avoid double-counting.
   if (delta !== 0) {
     shiftPositionsAfter(mod.__dom.children, endIndex + 1, delta);
   }
@@ -396,9 +402,32 @@ function isMultiLineConditional(node: { data?: string }): boolean {
   return inner.includes('\n');
 }
 
-function isInsideSingleLineConditional(textNode: SourceText, ranges: Array<[number, number]>): boolean {
-  for (const [start, end] of ranges) {
-    if (textNode.startIndex >= start && textNode.endIndex <= end) {
+/**
+ * Check whether a text node at `index` in `childArray` sits between
+ * two comments that form a single-line bubble conditional.  This is a
+ * position-independent check — it walks siblings by array index, so it
+ * survives source mutations that shift absolute offsets.
+ */
+function isTextBetweenBubbleComments(
+  index: number,
+  childArray: Array<SourceElement | SourceText | SourceChildNode>,
+  bubbleData: Set<string>
+): boolean {
+  // Scan backwards for a bubble open comment
+  let foundOpen = false;
+  for (let before = index - 1; before >= 0; before--) {
+    const node = childArray[before];
+    if (isComment(node) && bubbleData.has((node as { data?: string }).data ?? '')) {
+      foundOpen = true;
+      break;
+    }
+  }
+  if (!foundOpen) return false;
+
+  // Scan forwards for a bubble close comment
+  for (let after = index + 1; after < childArray.length; after++) {
+    const node = childArray[after];
+    if (isComment(node) && bubbleData.has((node as { data?: string }).data ?? '')) {
       return true;
     }
   }
@@ -417,9 +446,9 @@ function isInsideSingleLineConditional(textNode: SourceText, ranges: Array<[numb
 function isBubbleCommentBoundary(
   nodeA: SourceElement | SourceText | SourceChildNode,
   nodeB: SourceElement | SourceText | SourceChildNode,
-  bubbleData?: Set<string>
+  bubbleData: Set<string>
 ): boolean {
-  if (!bubbleData || bubbleData.size === 0) return false;
+  if (bubbleData.size === 0) return false;
   for (const node of [nodeA, nodeB]) {
     if (isComment(node)) {
       const data = (node as { data?: string }).data ?? '';
@@ -430,7 +459,7 @@ function isBubbleCommentBoundary(
 }
 
 // ---------------------------------------------------------------------------
-// Single-line conditional comment detection
+// Single-line bubble conditional comment detection
 // ---------------------------------------------------------------------------
 
 /**
@@ -438,6 +467,9 @@ function isBubbleCommentBoundary(
  * bubble/revealed conditionals.  For `<!--[if !mso]><!-->...<![endif]-->`,
  * the opening comment has data `[if !mso]><!` and the closing comment
  * has data `<![endif]`.  Both are added to the set.
+ *
+ * These are used for position-independent checks that survive source
+ * mutations during formatting.
  */
 function buildSingleLineBubbleCommentData(html: string): Set<string> {
   const comments = findConditionalComments(html);
@@ -458,20 +490,6 @@ function buildSingleLineBubbleCommentData(html: string): Set<string> {
   }
 
   return dataSet;
-}
-
-function buildSingleLineConditionalRanges(html: string): Array<[number, number]> {
-  const comments = findConditionalComments(html);
-  const ranges: Array<[number, number]> = [];
-
-  for (const comment of comments) {
-    const content = html.slice(comment.range[0] + comment.open.length, comment.range[1] - comment.close.length);
-    if (!content.includes('\n')) {
-      ranges.push(comment.range);
-    }
-  }
-
-  return ranges;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -1,6 +1,6 @@
 import findConditionalComments from '@ciolabs/html-find-conditional-comments';
 import { HtmlMod, HtmlModElement, HtmlModText } from '@ciolabs/html-mod';
-import type { SourceElement, SourceText } from '@ciolabs/htmlparser2-source';
+import type { SourceElement, SourceText, SourceChildNode } from '@ciolabs/htmlparser2-source';
 import { isComment, isTag, isText } from '@ciolabs/htmlparser2-source';
 
 /**
@@ -132,11 +132,10 @@ function formatChildren(
       } else if (isComment(child)) {
         insertBeforeComment(mod, child, `\n${childIndent}`);
       }
-    } else if (previous && !isText(previous) && !hasInlineBlockStyle(previous) && !hasInlineBlockStyle(child)) {
+    } else if (previous && !isText(previous) && !(hasInlineBlockStyle(previous) && hasInlineBlockStyle(child))) {
       // Two non-text nodes directly adjacent — insert whitespace between
-      // them.  Skip when either has display:inline-block — adjacent
-      // inline-block elements are a common email column pattern where
-      // any added whitespace breaks the layout on iOS/Android.
+      // them.  Skip only when BOTH are display:inline-block — that's the
+      // email column pattern where any gap breaks the layout on iOS/Android.
       if (isTag(previous)) {
         insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
       } else if (isComment(previous)) {
@@ -335,7 +334,7 @@ function isPreserved(element: SourceElement): boolean {
   return PRESERVE_CONTENT.has(element.tagName);
 }
 
-function hasInlineBlockStyle(node: unknown): boolean {
+function hasInlineBlockStyle(node: SourceChildNode): boolean {
   if (!isTag(node)) return false;
   const style = (node as SourceElement).attribs?.style ?? '';
   return /display\s*:\s*inline-block/i.test(style);

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -66,9 +66,22 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
   // We must not touch whitespace inside these.
   const singleLineRanges = buildSingleLineConditionalRanges(mod.__source);
 
+  // Build a set of comment data strings that belong to single-line
+  // bubble/revealed conditional comments.  These are the patterns
+  // like <!--[if !mso]><!-->...<!--<![endif]--> where inserting
+  // whitespace next to the comments would break inline-block layouts.
+  const singleLineBubbleCommentData = buildSingleLineBubbleCommentData(mod.__source);
+
   // Format the document tree.
   // Depth -1 so that top-level elements sit at indent 0.
-  formatChildren(mod, mod.__dom.children as Iterable<SourceElement | SourceText>, -1, indent, singleLineRanges);
+  formatChildren(
+    mod,
+    mod.__dom.children as Iterable<SourceElement | SourceText>,
+    -1,
+    indent,
+    singleLineRanges,
+    singleLineBubbleCommentData
+  );
 
   // Trim trailing whitespace on the document
   mod.trimEnd();
@@ -92,7 +105,8 @@ function formatChildren(
   children: Iterable<SourceElement | SourceText>,
   depth: number,
   indent: string,
-  singleLineRanges: Array<[number, number]>
+  singleLineRanges: Array<[number, number]>,
+  singleLineBubbleCommentData?: Set<string>
 ): void {
   const childArray = [...children];
 
@@ -135,10 +149,17 @@ function formatChildren(
       } else if (isComment(child)) {
         insertBeforeComment(mod, child, `\n${childIndent}`);
       }
-    } else if (previous && !isText(previous) && !(hasInlineBlockStyle(previous) && hasInlineBlockStyle(child))) {
+    } else if (
+      previous &&
+      !isText(previous) &&
+      !(hasInlineBlockStyle(previous) && hasInlineBlockStyle(child)) &&
+      !isBubbleCommentBoundary(previous, child, singleLineBubbleCommentData)
+    ) {
       // Two non-text nodes directly adjacent — insert whitespace between
-      // them.  Skip only when BOTH are display:inline-block — that's the
-      // email column pattern where any gap breaks the layout on iOS/Android.
+      // them.  Skip when:
+      // - BOTH are display:inline-block (email column pattern)
+      // - Either node is a comment belonging to a single-line bubble
+      //   conditional (e.g. <!--[if !mso]><!-->...<![endif]-->)
       if (isTag(previous)) {
         insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
       } else if (isComment(previous)) {
@@ -165,7 +186,8 @@ function formatChildren(
           element.children as Iterable<SourceElement | SourceText>,
           depth + 1,
           indent,
-          singleLineRanges
+          singleLineRanges,
+          singleLineBubbleCommentData
         );
       }
 
@@ -239,14 +261,20 @@ function formatInsideConditionalComment(
   // The caller passes `depth + 1`, so `depth` here equals the comment's
   // own indentation level in the outer document.
   const commentIndent = indent.repeat(Math.max(0, depth));
-  let innerFormatted = innerMod.__source.trimEnd();
 
-  // Ensure a leading newline so content starts on the line after <!--[if]>
-  if (!innerFormatted.startsWith('\n')) {
-    innerFormatted = `\n${commentIndent}${innerFormatted}`;
-  }
+  // When formatChildren was a no-op (e.g. closing tags like </td></tr></table>
+  // which htmlparser2 parses as text), re-indent every line to the comment's
+  // level.  Otherwise strip only the leading newline (formatChildren inserts
+  // one before the first child) but keep the indent.
+  const innerFormatted =
+    innerMod.__source === trimmedInnerHtml
+      ? trimmedInnerHtml
+          .split('\n')
+          .map(line => `${commentIndent}${line.trim()}`)
+          .join('\n')
+      : innerMod.__source.replace(/^\n/, '').trimEnd();
 
-  const formatted = `${innerFormatted}\n${commentIndent}`;
+  const formatted = `\n${innerFormatted}\n${commentIndent}`;
 
   const newData = `${openMatch[0]}${formatted}${closeMatch[0]}`;
   if (newData === data) return;
@@ -377,9 +405,60 @@ function isInsideSingleLineConditional(textNode: SourceText, ranges: Array<[numb
   return false;
 }
 
+/**
+ * Check whether either adjacent node is a comment that belongs to a
+ * single-line bubble/revealed conditional.  This protects patterns like
+ * `<!--[if !mso]><!-->...<![endif]-->` where inserting whitespace next
+ * to the comment would break inline-block layouts.
+ *
+ * Unlike position-range checks, this uses comment data strings which
+ * don't shift during formatting.
+ */
+function isBubbleCommentBoundary(
+  nodeA: SourceElement | SourceText | SourceChildNode,
+  nodeB: SourceElement | SourceText | SourceChildNode,
+  bubbleData?: Set<string>
+): boolean {
+  if (!bubbleData || bubbleData.size === 0) return false;
+  for (const node of [nodeA, nodeB]) {
+    if (isComment(node)) {
+      const data = (node as { data?: string }).data ?? '';
+      if (bubbleData.has(data)) return true;
+    }
+  }
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Single-line conditional comment detection
 // ---------------------------------------------------------------------------
+
+/**
+ * Collect the comment data strings for comments that form single-line
+ * bubble/revealed conditionals.  For `<!--[if !mso]><!-->...<![endif]-->`,
+ * the opening comment has data `[if !mso]><!` and the closing comment
+ * has data `<![endif]`.  Both are added to the set.
+ */
+function buildSingleLineBubbleCommentData(html: string): Set<string> {
+  const comments = findConditionalComments(html);
+  const dataSet = new Set<string>();
+
+  for (const comment of comments) {
+    if (!comment.bubble) continue;
+    const content = html.slice(comment.range[0] + comment.open.length, comment.range[1] - comment.close.length);
+    if (content.includes('\n')) continue;
+
+    // Extract the comment data from the open and close strings.
+    // <!--[if !mso]><!--> has comment data "[if !mso]><!"
+    // <!--<![endif]--> has comment data "<![endif]"
+    const openData = comment.open.slice(4, -3); // strip "<!--" and "-->"
+    const closeData = comment.close.slice(4, -3); // strip "<!--" and "-->"
+    if (openData) dataSet.add(openData);
+    if (closeData) dataSet.add(closeData);
+  }
+
+  return dataSet;
+}
 
 function buildSingleLineConditionalRanges(html: string): Array<[number, number]> {
   const comments = findConditionalComments(html);

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -1,13 +1,12 @@
 import findConditionalComments from '@ciolabs/html-find-conditional-comments';
-import { HtmlMod } from '@ciolabs/html-mod';
-import { preprocess, postprocess } from '@ciolabs/html-process-conditional-comments';
-import jsBeautify from 'js-beautify';
+import { HtmlMod, HtmlModElement, HtmlModText } from '@ciolabs/html-mod';
+import type { SourceElement, SourceText } from '@ciolabs/htmlparser2-source';
+import { isComment, isTag, isText } from '@ciolabs/htmlparser2-source';
 
 /**
- * Inline HTML elements — a formatter must never introduce whitespace
- * between adjacent inline elements when none existed in the source.
+ * Inline HTML elements — we never add newlines around these.
  */
-const INLINE_ELEMENTS = [
+const INLINE_ELEMENTS = new Set([
   'a',
   'abbr',
   'b',
@@ -35,195 +34,393 @@ const INLINE_ELEMENTS = [
   'time',
   'u',
   'var',
-];
+]);
 
-export type PrettifyOptions = jsBeautify.HTMLBeautifyOptions;
+/**
+ * Elements whose content whitespace must never be touched.
+ */
+const PRESERVE_CONTENT = new Set(['pre', 'code', 'textarea']);
+
+export interface PrettifyOptions {
+  /** Number of spaces per indent level (default 2) */
+  indentSize?: number;
+  /** Character to use for indentation (default ' ') */
+  indentChar?: string;
+}
 
 /**
  * Format and prettify HTML email content.
  *
- * Accepts an `HtmlMod` instance or a raw HTML string.
- * - If `HtmlMod`, the instance is mutated in place and returned.
- * - If `string`, a new `HtmlMod` is created from the formatted result.
+ * Walks the html-mod AST and adjusts whitespace text nodes in place —
+ * no re-parse, no full-string rewrite.  The `HtmlMod` instance stays
+ * live with valid positions throughout.
  *
- * Email-safe: preserves whitespace inside single-line conditional
- * comments, `<pre>`, `<code>`, and between adjacent inline elements.
+ * - If `HtmlMod`, the instance is mutated in place and returned.
+ * - If `string`, a new `HtmlMod` is created, formatted, and returned.
  */
 export default function prettify(input: HtmlMod | string, options?: PrettifyOptions): HtmlMod {
-  const isHtmlMod = input instanceof HtmlMod;
-  let html = isHtmlMod ? input.__source : input;
+  const mod = input instanceof HtmlMod ? input : new HtmlMod(input);
+  const indent = (options?.indentChar ?? ' ').repeat(options?.indentSize ?? 2);
 
-  // Step 1: Record single-line conditional comments so we can restore them
-  const originalComments = findConditionalComments(html);
-  const singleLineSnapshots: SingleLineSnapshot[] = [];
+  // Build a set of character ranges for single-line conditional comments.
+  // We must not touch whitespace inside these.
+  const singleLineRanges = buildSingleLineConditionalRanges(mod.__source);
 
-  for (const [commentIndex, comment] of originalComments.entries()) {
-    const content = html.slice(comment.range[0] + comment.open.length, comment.range[1] - comment.close.length);
+  // Format the document tree.
+  // Depth -1 so that top-level elements sit at indent 0.
+  formatChildren(mod, mod.__dom.children as Iterable<SourceElement | SourceText>, -1, indent, singleLineRanges);
 
-    if (!content.includes('\n')) {
-      singleLineSnapshots.push({
-        index: commentIndex,
-        content,
-        open: comment.open,
-        close: comment.close,
-      });
+  // Trim trailing whitespace on the document
+  mod.trimEnd();
+  // Trim leading empty lines
+  mod.trimStart();
+
+  return mod;
+}
+
+// ---------------------------------------------------------------------------
+// Core formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk `children` and ensure correct indentation between block-level
+ * siblings.  Operates entirely through HtmlMod text-node mutations so
+ * the AST stays in sync.
+ */
+function formatChildren(
+  mod: HtmlMod,
+  children: Iterable<SourceElement | SourceText>,
+  depth: number,
+  indent: string,
+  singleLineRanges: Array<[number, number]>
+): void {
+  const childArray = [...children];
+
+  // Determine if this list contains any block-level elements.
+  // If it's all inline / text / comments we leave it alone.
+  const hasBlock = childArray.some(
+    child => isTag(child) && !isInline(child as SourceElement) && !isPreserved(child as SourceElement)
+  );
+
+  if (!hasBlock) return;
+
+  const childIndent = indent.repeat(Math.max(0, depth + 1));
+  const parentIndent = indent.repeat(Math.max(0, depth));
+
+  for (let index = 0; index < childArray.length; index++) {
+    const child = childArray[index];
+
+    // --- Whitespace text nodes between siblings --------------------------
+    // In a block context, normalize whitespace-only text nodes to the
+    // correct indentation regardless of what follows (block or inline).
+    if (isText(child)) {
+      const textNode = child as SourceText;
+      if (isWhitespaceOnly(textNode.data) && !isInsideSingleLineConditional(textNode, singleLineRanges)) {
+        // Determine what indent to use: if this is the last child
+        // (whitespace before parent close tag), use parentIndent.
+        const isLast = index === childArray.length - 1;
+        setTextContent(mod, textNode, `\n${isLast ? parentIndent : childIndent}`);
+      }
+      continue;
+    }
+
+    // --- Element nodes ---------------------------------------------------
+    if (isTag(child)) {
+      const element = child as SourceElement;
+
+      // If first child and no leading text node, insert whitespace
+      const previous = childArray[index - 1];
+      if (!previous) {
+        insertBeforeIfNeeded(mod, element, `\n${childIndent}`);
+      }
+
+      // Skip recursion for inline elements — only adjust surrounding whitespace
+      if (isInline(element)) {
+        // If last child, ensure trailing whitespace before parent close
+        if (index === childArray.length - 1) {
+          insertAfterIfNeeded(mod, element, `\n${parentIndent}`);
+        }
+        continue;
+      }
+
+      // Recurse into children (unless content is preserved)
+      if (!isPreserved(element) && element.children.length > 0) {
+        formatChildren(
+          mod,
+          element.children as Iterable<SourceElement | SourceText>,
+          depth + 1,
+          indent,
+          singleLineRanges
+        );
+      }
+
+      // Fix trailing whitespace (before next sibling or before parent close tag)
+      const next = childArray[index + 1];
+      if (!next) {
+        // Last child — ensure whitespace before parent close tag
+        insertAfterIfNeeded(mod, element, `\n${parentIndent}`);
+      }
+    }
+
+    // --- Comment nodes ----------------------------------------------------
+    if (isComment(child)) {
+      // Fix leading whitespace before this comment
+      const previous = childArray[index - 1];
+      if (previous && isText(previous)) {
+        const textNode = previous as SourceText;
+        if (isWhitespaceOnly(textNode.data) && !isInsideSingleLineConditional(textNode, singleLineRanges)) {
+          setTextContent(mod, textNode, `\n${childIndent}`);
+        }
+      }
+
+      // Fix trailing whitespace
+      const next = childArray[index + 1];
+      if (!next) {
+        // Comment is last child — add whitespace before parent close
+        insertAfterComment(mod, child, `\n${parentIndent}`);
+      }
+
+      // Format inside multi-line conditional comments
+      if (isMultiLineConditional(child)) {
+        formatInsideConditionalComment(mod, child, depth + 1, indent, singleLineRanges);
+      }
     }
   }
-
-  // Step 2: Preprocess conditional comments — expose inner HTML for formatting
-  html = preprocess(html);
-
-  // Step 3: Format with js-beautify
-  // eslint-disable-next-line camelcase
-  html = jsBeautify.html(html, {
-    indent_size: 2, // eslint-disable-line camelcase
-    indent_char: ' ', // eslint-disable-line camelcase
-    wrap_line_length: 0, // eslint-disable-line camelcase
-    preserve_newlines: true, // eslint-disable-line camelcase
-    max_preserve_newlines: 1, // eslint-disable-line camelcase
-    indent_inner_html: true, // eslint-disable-line camelcase
-    extra_liners: [], // eslint-disable-line camelcase
-    content_unformatted: ['pre', 'code', 'textarea'], // eslint-disable-line camelcase
-    inline: INLINE_ELEMENTS,
-    unformatted: [],
-    ...options,
-  });
-
-  // Step 4: Postprocess conditional comments — close them back up
-  html = postprocess(html);
-
-  // Step 5: Restore single-line conditional comments to their original content
-  html = restoreSingleLineComments(html, singleLineSnapshots);
-
-  // Step 6: Align open/close indentation of multi-line conditional comments
-  html = alignConditionalComments(html);
-
-  // Step 7: Return HtmlMod
-  if (isHtmlMod) {
-    resetHtmlMod(input, html);
-    return input;
-  }
-
-  return new HtmlMod(html);
 }
 
 // ---------------------------------------------------------------------------
-// Internal types
-// ---------------------------------------------------------------------------
-
-interface SingleLineSnapshot {
-  /** Index in the original findConditionalComments array */
-  index: number;
-  /** The HTML content between open and close (no newlines) */
-  content: string;
-  /** The opening syntax, e.g. `<!--[if mso]>` */
-  open: string;
-  /** The closing syntax, e.g. `<![endif]-->` */
-  close: string;
-}
-
-// ---------------------------------------------------------------------------
-// Restore single-line conditional comments
+// Multi-line conditional comment formatting
 // ---------------------------------------------------------------------------
 
 /**
- * After formatting, conditional comments that were originally on a single
- * line may have been expanded across multiple lines.  This puts them back.
+ * Format the HTML content inside a multi-line conditional comment.
  *
- * We match by index position in the `findConditionalComments` array and
- * verify the open/close strings still match before restoring.
+ * The comment content looks like: `[if mso]>\n<table>...\n<![endif]`
+ * We extract the inner HTML, format it in a temporary HtmlMod, and
+ * splice the result back into the comment.
  */
-function restoreSingleLineComments(html: string, snapshots: SingleLineSnapshot[]): string {
-  if (snapshots.length === 0) return html;
+function formatInsideConditionalComment(
+  mod: HtmlMod,
+  commentNode: { startIndex: number; endIndex: number; data: string },
+  depth: number,
+  indent: string,
+  _singleLineRanges: Array<[number, number]>
+): void {
+  const { data, startIndex, endIndex } = commentNode;
 
-  const comments = findConditionalComments(html);
+  // Extract the opening conditional (e.g., "[if mso]>") and closing (e.g., "<![endif]")
+  const openMatch = /^\[if\s[^]*?]>/.exec(data);
+  const closeMatch = /<!\[endif]$/.exec(data);
+  if (!openMatch || !closeMatch) return;
 
-  // Process in reverse so earlier indices aren't shifted by replacements
-  for (const snapshot of [...snapshots].reverse()) {
-    if (snapshot.index >= comments.length) continue;
-    const formatted = comments[snapshot.index];
+  const innerHtml = data.slice(openMatch[0].length, data.length - closeMatch[0].length);
+  if (!innerHtml.trim()) return;
 
-    // Safety: make sure it's the same comment
-    if (formatted.open !== snapshot.open || formatted.close !== snapshot.close) continue;
+  // Format the inner HTML in a scoped HtmlMod
+  const innerMod = new HtmlMod(innerHtml);
+  const innerSingleLineRanges = buildSingleLineConditionalRanges(innerHtml);
+  formatChildren(
+    innerMod,
+    innerMod.__dom.children as Iterable<SourceElement | SourceText>,
+    depth,
+    indent,
+    innerSingleLineRanges
+  );
 
-    const restored = snapshot.open + snapshot.content + snapshot.close;
-    html = html.slice(0, formatted.range[0]) + restored + html.slice(formatted.range[1]);
+  let formatted = innerMod.__source;
+
+  // Ensure leading newline and trailing newline + indent for alignment
+  const parentIndent = indent.repeat(Math.max(0, depth - 1));
+  formatted = formatted.startsWith('\n') ? formatted : `\n${formatted}`;
+
+  formatted = formatted.endsWith('\n')
+    ? formatted.replace(/\n\s*$/, `\n${parentIndent}`)
+    : `${formatted}\n${parentIndent}`;
+
+  const newData = `${openMatch[0]}${formatted}${closeMatch[0]}`;
+  if (newData === data) return;
+
+  // Overwrite the comment content in the source string.
+  // Comment source in htmlparser2: <!--DATA-->
+  // startIndex points to '<', data starts at startIndex + 4 (after '<!--')
+  const dataStart = startIndex + 4;
+  const dataEnd = endIndex - 2; // before '-->'
+  const oldLength = dataEnd - dataStart;
+  const { length: newLength } = newData;
+
+  mod.__source = mod.__source.slice(0, dataStart) + newData + mod.__source.slice(dataStart + oldLength);
+
+  // Update the comment node and track the delta
+  const delta = newLength - oldLength;
+  commentNode.data = newData;
+  commentNode.endIndex += delta;
+
+  // Shift all nodes after this comment
+  if (delta !== 0) {
+    shiftPositionsAfter(mod.__dom.children, endIndex + 1, delta);
   }
-
-  return html;
 }
 
 // ---------------------------------------------------------------------------
-// Align conditional comment indentation
+// Text node helpers
 // ---------------------------------------------------------------------------
 
-/**
- * For multi-line conditional comments, ensure the opening and closing
- * tags sit at the same indentation level.
- */
-function alignConditionalComments(html: string): string {
-  const comments = findConditionalComments(html);
+function setTextContent(mod: HtmlMod, textNode: SourceText, content: string): void {
+  if (textNode.data === content) return;
+  const textWrapper = new HtmlModText(textNode, mod);
+  textWrapper.innerHTML = content;
+}
 
-  // Collect alignment adjustments
-  const adjustments: Array<[number, number, string]> = [];
+function insertBeforeIfNeeded(mod: HtmlMod, element: SourceElement, whitespace: string): void {
+  // Check if there's already whitespace before this element
+  const charBefore = mod.__source[element.source.openTag.startIndex - 1];
+  if (charBefore === '>' || charBefore === undefined) {
+    // No whitespace — insert via element wrapper
+    const wrapper = new HtmlModElement(element, mod);
+    wrapper.before(whitespace);
+  }
+}
+
+function insertAfterIfNeeded(mod: HtmlMod, element: SourceElement, whitespace: string): void {
+  const endPos = element.source.closeTag?.endIndex ?? element.endIndex + 1;
+  const charAfter = mod.__source[endPos];
+  if (charAfter === '<' || charAfter === undefined) {
+    const wrapper = new HtmlModElement(element, mod);
+    wrapper.after(whitespace);
+  }
+}
+
+function insertAfterComment(
+  mod: HtmlMod,
+  commentNode: { startIndex: number; endIndex: number },
+  whitespace: string
+): void {
+  const endPos = commentNode.endIndex + 1;
+  const charAfter = mod.__source[endPos];
+  if (charAfter === '<' || charAfter === undefined) {
+    mod.__appendRight(endPos, whitespace);
+    // Shift nodes after
+    shiftPositionsAfter(mod.__dom.children, endPos, whitespace.length);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Classification helpers
+// ---------------------------------------------------------------------------
+
+function isInline(element: SourceElement): boolean {
+  return INLINE_ELEMENTS.has(element.tagName);
+}
+
+function isPreserved(element: SourceElement): boolean {
+  return PRESERVE_CONTENT.has(element.tagName);
+}
+
+function isWhitespaceOnly(string_: string): boolean {
+  return /^\s*$/.test(string_);
+}
+
+function isMultiLineConditional(node: { data?: string }): boolean {
+  if (!node.data) return false;
+  const { data } = node;
+  if (!data.startsWith('[if ')) return false;
+  if (!data.endsWith('<![endif]')) return false;
+  // Extract inner content
+  const openMatch = /^\[if\s[^]*?]>/.exec(data);
+  if (!openMatch) return false;
+  const inner = data.slice(openMatch[0].length, data.length - '<![endif]'.length);
+  return inner.includes('\n');
+}
+
+function isInsideSingleLineConditional(textNode: SourceText, ranges: Array<[number, number]>): boolean {
+  for (const [start, end] of ranges) {
+    if (textNode.startIndex >= start && textNode.endIndex <= end) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Single-line conditional comment detection
+// ---------------------------------------------------------------------------
+
+function buildSingleLineConditionalRanges(html: string): Array<[number, number]> {
+  const comments = findConditionalComments(html);
+  const ranges: Array<[number, number]> = [];
 
   for (const comment of comments) {
-    const commentChars = new Set(html.slice(comment.range[0], comment.range[1]));
-    if (!commentChars.has('\n') && !commentChars.has('\r')) continue;
-
-    const { whitespace: openWs } = parseLastLine(html.slice(0, Math.max(0, comment.range[0])));
-
-    const { whitespace: closeWs, text: closeText } = parseLastLine(
-      html.slice(comment.range[0], comment.range[1] - comment.close.length)
-    );
-
-    if (openWs.length === closeWs.length) continue;
-
-    if (openWs.length > closeWs.length) {
-      // Reduce opening indent to match closing
-      adjustments.push([comment.range[0] - openWs.length, comment.range[0], closeWs]);
-    } else {
-      // Reduce closing indent to match opening
-      const closeFullLength = closeWs.length + closeText.length;
-      adjustments.push([
-        comment.range[1] - comment.close.length - closeFullLength,
-        comment.range[1] - comment.close.length - closeText.length,
-        openWs,
-      ]);
+    const content = html.slice(comment.range[0] + comment.open.length, comment.range[1] - comment.close.length);
+    if (!content.includes('\n')) {
+      ranges.push(comment.range);
     }
   }
 
-  // Apply adjustments from end to start so indices stay valid
-  adjustments.sort((a, b) => b[0] - a[0]);
-  for (const [start, end, replacement] of adjustments) {
-    html = html.slice(0, start) + replacement + html.slice(end);
-  }
-
-  return html;
-}
-
-function parseLastLine(string_: string): { whitespace: string; text: string } {
-  const lastLine = string_.split('\n').at(-1) ?? '';
-  const match = /^[^\S\n\r]*/.exec(lastLine);
-  const whitespace = match ? match[0] : '';
-  const text = lastLine.slice(whitespace.length);
-  return { whitespace, text };
+  return ranges;
 }
 
 // ---------------------------------------------------------------------------
-// HtmlMod mutation
+// Position shifting
 // ---------------------------------------------------------------------------
+
+interface AstNode {
+  startIndex: number;
+  endIndex: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  children?: Iterable<any>;
+  data?: string;
+  source?: {
+    openTag: { startIndex: number; endIndex: number };
+    closeTag?: { startIndex: number; endIndex: number } | null;
+    attributes?: Array<{
+      name: { startIndex: number; endIndex: number };
+      value?: { startIndex: number; endIndex: number } | null;
+      source: { startIndex: number; endIndex: number };
+    }>;
+  };
+}
 
 /**
- * Reset an existing HtmlMod so its internal state reflects `newSource`.
- * We create a throwaway HtmlMod to parse the source, then copy
- * the parsed DOM and bookkeeping into the original instance.
+ * After a raw string mutation, shift all AST node positions that come
+ * after `afterPos` by `delta` characters.
  */
-function resetHtmlMod(mod: HtmlMod, newSource: string): void {
-  const fresh = new HtmlMod(newSource, mod.__options);
-  mod.__source = fresh.__source;
-  mod.__dom = fresh.__dom;
-  mod.__astUpdater = fresh.__astUpdater;
-  mod.__cachedInnerHTML = new WeakMap();
-  mod.__cachedOuterHTML = new WeakMap();
+function shiftPositionsAfter(nodes: Iterable<AstNode>, afterPos: number, delta: number): void {
+  for (const node of nodes) {
+    if (node.startIndex >= afterPos) {
+      node.startIndex += delta;
+      node.endIndex += delta;
+
+      // For tag elements, shift source positions too
+      if (node.source?.openTag) {
+        node.source.openTag.startIndex += delta;
+        node.source.openTag.endIndex += delta;
+        if (node.source.closeTag) {
+          node.source.closeTag.startIndex += delta;
+          node.source.closeTag.endIndex += delta;
+        }
+        for (const attribute of node.source.attributes ?? []) {
+          attribute.name.startIndex += delta;
+          attribute.name.endIndex += delta;
+          if (attribute.value) {
+            attribute.value.startIndex += delta;
+            attribute.value.endIndex += delta;
+          }
+          attribute.source.startIndex += delta;
+          attribute.source.endIndex += delta;
+        }
+      }
+    } else if (node.endIndex >= afterPos) {
+      // Node spans the edit point — only shift endIndex
+      node.endIndex += delta;
+      if (node.source?.closeTag && node.source.closeTag.startIndex >= afterPos) {
+        node.source.closeTag.startIndex += delta;
+        node.source.closeTag.endIndex += delta;
+      }
+    }
+
+    // Recurse into children
+    if (node.children) {
+      shiftPositionsAfter(node.children, afterPos, delta);
+    }
+  }
 }

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -567,12 +567,14 @@ function hasInlineBlockStyle(node: SourceChildNode): boolean {
   return /display\s*:\s*inline-block/i.test(style);
 }
 
+/** Bubble open: `<!--[if !mso]><!-->` or `<!--[if !mso]><!-- -->` */
 function isBubbleOpenData(data: string): boolean {
-  return /\[if\s/i.test(data) && data.endsWith('><!');
+  return /\[if\s/i.test(data) && /><!\s*$/.test(data);
 }
 
+/** Bubble close: `<!--<![endif]-->` or `<!-- <![endif]-->` */
 function isBubbleCloseData(data: string): boolean {
-  return /\[endif]/i.test(data) && data.startsWith('<!');
+  return /\[endif]/i.test(data) && /^\s*<!/.test(data);
 }
 
 function isWhitespaceOnly(string_: string): boolean {

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -244,7 +244,8 @@ function formatInsideConditionalComment(
   if (!openMatch || !closeMatch) return;
 
   const rawInnerHtml = data.slice(openMatch[0].length, data.length - closeMatch[0].length);
-  const trimmedInnerHtml = rawInnerHtml.trim();
+  // Trim only HTML formatting whitespace — preserve NBSP and Unicode spaces
+  const trimmedInnerHtml = rawInnerHtml.replace(/^[\t\n\f\r ]+/, '').replace(/[\t\n\f\r ]+$/, '');
   if (!trimmedInnerHtml) return;
 
   // Format the inner HTML in a scoped HtmlMod.
@@ -269,9 +270,9 @@ function formatInsideConditionalComment(
     innerMod.__source === trimmedInnerHtml
       ? trimmedInnerHtml
           .split('\n')
-          .map(line => `${commentIndent}${line.trim()}`)
+          .map(line => `${commentIndent}${trimFormatting(line)}`)
           .join('\n')
-      : innerMod.__source.replace(/^\n/, '').trimEnd();
+      : innerMod.__source.replace(/^\n/, '').replace(/[\t\n\f\r ]+$/, '');
 
   const formatted = `\n${innerFormatted}\n${commentIndent}`;
 
@@ -370,7 +371,11 @@ function isPreserved(element: SourceElement): boolean {
 
 function hasInlineBlockStyle(node: SourceChildNode): boolean {
   if (!isTag(node)) return false;
-  const style = (node as SourceElement).attribs?.style ?? '';
+  const { attribs } = node as SourceElement;
+  if (!attribs) return false;
+  // Case-insensitive attribute lookup to handle lowerCaseAttributeNames: false
+  const styleKey = Object.keys(attribs).find(k => k.toLowerCase() === 'style');
+  const style = styleKey ? attribs[styleKey] : '';
   return /display\s*:\s*inline-block/i.test(style);
 }
 
@@ -391,6 +396,11 @@ function isBubbleCloseData(data: string): boolean {
  */
 function isWhitespaceOnly(string_: string): boolean {
   return /^[\t\n\f\r ]*$/.test(string_);
+}
+
+/** Strip leading and trailing HTML formatting whitespace, preserving NBSP. */
+function trimFormatting(string_: string): string {
+  return string_.replace(/^[\t\n\f\r ]+/, '').replace(/[\t\n\f\r ]+$/, '');
 }
 
 /**

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -1,0 +1,229 @@
+import findConditionalComments from '@ciolabs/html-find-conditional-comments';
+import { HtmlMod } from '@ciolabs/html-mod';
+import { preprocess, postprocess } from '@ciolabs/html-process-conditional-comments';
+import jsBeautify from 'js-beautify';
+
+/**
+ * Inline HTML elements — a formatter must never introduce whitespace
+ * between adjacent inline elements when none existed in the source.
+ */
+const INLINE_ELEMENTS = [
+  'a',
+  'abbr',
+  'b',
+  'bdo',
+  'br',
+  'cite',
+  'code',
+  'del',
+  'dfn',
+  'em',
+  'i',
+  'img',
+  'ins',
+  'kbd',
+  'label',
+  'mark',
+  'q',
+  's',
+  'samp',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'time',
+  'u',
+  'var',
+];
+
+export type PrettifyOptions = jsBeautify.HTMLBeautifyOptions;
+
+/**
+ * Format and prettify HTML email content.
+ *
+ * Accepts an `HtmlMod` instance or a raw HTML string.
+ * - If `HtmlMod`, the instance is mutated in place and returned.
+ * - If `string`, a new `HtmlMod` is created from the formatted result.
+ *
+ * Email-safe: preserves whitespace inside single-line conditional
+ * comments, `<pre>`, `<code>`, and between adjacent inline elements.
+ */
+export default function prettify(input: HtmlMod | string, options?: PrettifyOptions): HtmlMod {
+  const isHtmlMod = input instanceof HtmlMod;
+  let html = isHtmlMod ? input.__source : input;
+
+  // Step 1: Record single-line conditional comments so we can restore them
+  const originalComments = findConditionalComments(html);
+  const singleLineSnapshots: SingleLineSnapshot[] = [];
+
+  for (const [commentIndex, comment] of originalComments.entries()) {
+    const content = html.slice(comment.range[0] + comment.open.length, comment.range[1] - comment.close.length);
+
+    if (!content.includes('\n')) {
+      singleLineSnapshots.push({
+        index: commentIndex,
+        content,
+        open: comment.open,
+        close: comment.close,
+      });
+    }
+  }
+
+  // Step 2: Preprocess conditional comments — expose inner HTML for formatting
+  html = preprocess(html);
+
+  // Step 3: Format with js-beautify
+  // eslint-disable-next-line camelcase
+  html = jsBeautify.html(html, {
+    indent_size: 2, // eslint-disable-line camelcase
+    indent_char: ' ', // eslint-disable-line camelcase
+    wrap_line_length: 0, // eslint-disable-line camelcase
+    preserve_newlines: true, // eslint-disable-line camelcase
+    max_preserve_newlines: 1, // eslint-disable-line camelcase
+    indent_inner_html: true, // eslint-disable-line camelcase
+    extra_liners: [], // eslint-disable-line camelcase
+    content_unformatted: ['pre', 'code', 'textarea'], // eslint-disable-line camelcase
+    inline: INLINE_ELEMENTS,
+    unformatted: [],
+    ...options,
+  });
+
+  // Step 4: Postprocess conditional comments — close them back up
+  html = postprocess(html);
+
+  // Step 5: Restore single-line conditional comments to their original content
+  html = restoreSingleLineComments(html, singleLineSnapshots);
+
+  // Step 6: Align open/close indentation of multi-line conditional comments
+  html = alignConditionalComments(html);
+
+  // Step 7: Return HtmlMod
+  if (isHtmlMod) {
+    resetHtmlMod(input, html);
+    return input;
+  }
+
+  return new HtmlMod(html);
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface SingleLineSnapshot {
+  /** Index in the original findConditionalComments array */
+  index: number;
+  /** The HTML content between open and close (no newlines) */
+  content: string;
+  /** The opening syntax, e.g. `<!--[if mso]>` */
+  open: string;
+  /** The closing syntax, e.g. `<![endif]-->` */
+  close: string;
+}
+
+// ---------------------------------------------------------------------------
+// Restore single-line conditional comments
+// ---------------------------------------------------------------------------
+
+/**
+ * After formatting, conditional comments that were originally on a single
+ * line may have been expanded across multiple lines.  This puts them back.
+ *
+ * We match by index position in the `findConditionalComments` array and
+ * verify the open/close strings still match before restoring.
+ */
+function restoreSingleLineComments(html: string, snapshots: SingleLineSnapshot[]): string {
+  if (snapshots.length === 0) return html;
+
+  const comments = findConditionalComments(html);
+
+  // Process in reverse so earlier indices aren't shifted by replacements
+  for (const snapshot of [...snapshots].reverse()) {
+    if (snapshot.index >= comments.length) continue;
+    const formatted = comments[snapshot.index];
+
+    // Safety: make sure it's the same comment
+    if (formatted.open !== snapshot.open || formatted.close !== snapshot.close) continue;
+
+    const restored = snapshot.open + snapshot.content + snapshot.close;
+    html = html.slice(0, formatted.range[0]) + restored + html.slice(formatted.range[1]);
+  }
+
+  return html;
+}
+
+// ---------------------------------------------------------------------------
+// Align conditional comment indentation
+// ---------------------------------------------------------------------------
+
+/**
+ * For multi-line conditional comments, ensure the opening and closing
+ * tags sit at the same indentation level.
+ */
+function alignConditionalComments(html: string): string {
+  const comments = findConditionalComments(html);
+
+  // Collect alignment adjustments
+  const adjustments: Array<[number, number, string]> = [];
+
+  for (const comment of comments) {
+    const commentChars = new Set(html.slice(comment.range[0], comment.range[1]));
+    if (!commentChars.has('\n') && !commentChars.has('\r')) continue;
+
+    const { whitespace: openWs } = parseLastLine(html.slice(0, Math.max(0, comment.range[0])));
+
+    const { whitespace: closeWs, text: closeText } = parseLastLine(
+      html.slice(comment.range[0], comment.range[1] - comment.close.length)
+    );
+
+    if (openWs.length === closeWs.length) continue;
+
+    if (openWs.length > closeWs.length) {
+      // Reduce opening indent to match closing
+      adjustments.push([comment.range[0] - openWs.length, comment.range[0], closeWs]);
+    } else {
+      // Reduce closing indent to match opening
+      const closeFullLength = closeWs.length + closeText.length;
+      adjustments.push([
+        comment.range[1] - comment.close.length - closeFullLength,
+        comment.range[1] - comment.close.length - closeText.length,
+        openWs,
+      ]);
+    }
+  }
+
+  // Apply adjustments from end to start so indices stay valid
+  adjustments.sort((a, b) => b[0] - a[0]);
+  for (const [start, end, replacement] of adjustments) {
+    html = html.slice(0, start) + replacement + html.slice(end);
+  }
+
+  return html;
+}
+
+function parseLastLine(string_: string): { whitespace: string; text: string } {
+  const lastLine = string_.split('\n').at(-1) ?? '';
+  const match = /^[^\S\n\r]*/.exec(lastLine);
+  const whitespace = match ? match[0] : '';
+  const text = lastLine.slice(whitespace.length);
+  return { whitespace, text };
+}
+
+// ---------------------------------------------------------------------------
+// HtmlMod mutation
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset an existing HtmlMod so its internal state reflects `newSource`.
+ * We create a throwaway HtmlMod to parse the source, then copy
+ * the parsed DOM and bookkeeping into the original instance.
+ */
+function resetHtmlMod(mod: HtmlMod, newSource: string): void {
+  const fresh = new HtmlMod(newSource, mod.__options);
+  mod.__source = fresh.__source;
+  mod.__dom = fresh.__dom;
+  mod.__astUpdater = fresh.__astUpdater;
+  mod.__cachedInnerHTML = new WeakMap();
+  mod.__cachedOuterHTML = new WeakMap();
+}

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -59,8 +59,60 @@ const PRESERVE_CONTENT = new Set(['pre', 'code', 'textarea']);
 export interface PrettifyOptions {
   /** Number of spaces per indent level (default 2) */
   indentSize?: number;
+
   /** Character to use for indentation (default ' ') */
   indentChar?: string;
+
+  /**
+   * Maximum line length before attribute wrapping kicks in (default 0 = off).
+   * When an opening tag exceeds this length, attributes are wrapped onto
+   * new lines (one per line, indented to align or by one indent level).
+   */
+  maxLineLength?: number;
+
+  /**
+   * How to wrap attributes when a tag exceeds `maxLineLength`.
+   * - `'auto'`          — wrap only when the line exceeds maxLineLength (default)
+   * - `'force'`         — always wrap attributes, one per line
+   * - `'force-aligned'` — always wrap, align to the first attribute
+   * - `false`           — never wrap attributes
+   */
+  wrapAttributes?: 'auto' | 'force' | 'force-aligned' | false;
+
+  /**
+   * Collapse multiple consecutive blank lines to a single blank line
+   * (default true).
+   */
+  collapseBlankLines?: boolean;
+
+  /**
+   * Whether to increase indentation depth for content that appears
+   * after a conditional comment.  When `false`, content after
+   * `<!--[if mso]>...<![endif]-->` stays at the same indent level
+   * as the comment itself (default true).
+   */
+  indentAfterConditionalComments?: boolean;
+}
+
+/** Resolved options with defaults applied */
+interface ResolvedOptions {
+  indent: string;
+  maxLineLength: number;
+  wrapAttributes: 'auto' | 'force' | 'force-aligned' | false;
+  collapseBlankLines: boolean;
+  indentAfterConditionalComments: boolean;
+}
+
+function resolveOptions(options?: PrettifyOptions): ResolvedOptions {
+  const indentChar = options?.indentChar ?? ' ';
+  const indentSize = options?.indentSize ?? 2;
+  return {
+    indent: indentChar.repeat(indentSize),
+    maxLineLength: options?.maxLineLength ?? 0,
+    wrapAttributes: options?.wrapAttributes ?? 'auto',
+    collapseBlankLines: options?.collapseBlankLines ?? true,
+    indentAfterConditionalComments: options?.indentAfterConditionalComments ?? true,
+  };
 }
 
 /**
@@ -75,14 +127,23 @@ export interface PrettifyOptions {
  */
 export default function prettify(input: HtmlMod | string, options?: PrettifyOptions): HtmlMod {
   const mod = typeof input === 'string' ? new HtmlMod(input) : input;
-  const indent = (options?.indentChar ?? ' ').repeat(options?.indentSize ?? 2);
+  const resolved = resolveOptions(options);
 
   // Format the document tree.
   // Depth -1 so that top-level elements sit at indent 0.
-  formatChildren(mod, mod.__dom.children as Iterable<SourceElement | SourceText>, -1, indent);
+  formatChildren(mod, mod.__dom.children as Iterable<SourceElement | SourceText>, -1, resolved);
+
+  // Wrap long opening tags by breaking attributes onto new lines.
+  if (resolved.wrapAttributes !== false && resolved.maxLineLength > 0) {
+    wrapLongAttributes(mod, resolved);
+  }
+
+  // Collapse consecutive blank lines.
+  if (resolved.collapseBlankLines) {
+    collapseConsecutiveBlankLines(mod);
+  }
 
   // Trim only HTML formatting whitespace at document boundaries.
-  // Preserve NBSP (\u00A0) and other semantic Unicode spaces.
   trimFormattingWhitespace(mod);
 
   return mod;
@@ -101,15 +162,12 @@ function formatChildren(
   mod: HtmlMod,
   children: Iterable<SourceElement | SourceText>,
   depth: number,
-  indent: string
+  options: ResolvedOptions
 ): void {
   const childArray = [...children];
+  const { indent } = options;
 
   // Determine if this list contains any block-level content.
-  // If it's all inline / text we leave it alone.
-  // Preserved elements (pre, code, textarea) count as block — we format
-  // whitespace *around* them, just not inside them.
-  // Multi-line conditional comments also count — they need internal formatting.
   const hasBlock = childArray.some(
     child =>
       (isTag(child) && !isInline(child as SourceElement)) ||
@@ -119,9 +177,7 @@ function formatChildren(
 
   if (!hasBlock) return;
 
-  // Build a set of child indices that are protected by single-line bubble
-  // conditional pairs.  Computed per sibling list so a single-line bubble
-  // doesn't accidentally protect a multi-line bubble later in the same list.
+  // Build a set of child indices protected by single-line bubble conditionals.
   const protectedIndices = buildProtectedBubbleIndices(childArray);
 
   const childIndent = indent.repeat(Math.max(0, depth + 1));
@@ -134,11 +190,6 @@ function formatChildren(
     const isLast = index === childArray.length - 1;
 
     // --- Whitespace text nodes between siblings --------------------------
-    // In a block context, normalize whitespace-only text nodes to the
-    // correct indentation regardless of what follows (block or inline).
-    // Skip when:
-    // - The index is protected by a single-line bubble conditional pair
-    // - The text separates two display:inline-block elements (column gap)
     if (isText(child)) {
       const textNode = child as SourceText;
       const nextSibling = childArray[index + 1];
@@ -153,7 +204,6 @@ function formatChildren(
 
     // --- Ensure leading whitespace before any non-text node ---------------
     if (isFirst) {
-      // First child — insert whitespace after parent open tag.
       if (isTag(child)) {
         insertBeforeIfNeeded(mod, child as SourceElement, `\n${childIndent}`);
       } else if (isComment(child) || isDirective(child)) {
@@ -165,10 +215,6 @@ function formatChildren(
       !(hasInlineBlockStyle(previous) && hasInlineBlockStyle(child)) &&
       !protectedIndices.has(index)
     ) {
-      // Two non-text nodes directly adjacent — insert whitespace between
-      // them.  Skip when:
-      // - BOTH are display:inline-block (email column pattern)
-      // - The index is protected by a single-line bubble conditional pair
       if (isTag(previous)) {
         insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
       } else if (isComment(previous) || isDirective(previous)) {
@@ -180,7 +226,6 @@ function formatChildren(
     if (isTag(child)) {
       const element = child as SourceElement;
 
-      // Skip recursion for inline elements
       if (isInline(element)) {
         if (isLast) {
           insertAfterIfNeeded(mod, element, `\n${parentIndent}`);
@@ -190,10 +235,9 @@ function formatChildren(
 
       // Recurse into children (unless content is preserved)
       if (!isPreserved(element) && element.children.length > 0) {
-        formatChildren(mod, element.children as Iterable<SourceElement | SourceText>, depth + 1, indent);
+        formatChildren(mod, element.children as Iterable<SourceElement | SourceText>, depth + 1, options);
       }
 
-      // Ensure trailing whitespace if last child
       if (isLast) {
         insertAfterIfNeeded(mod, element, `\n${parentIndent}`);
       }
@@ -201,14 +245,12 @@ function formatChildren(
 
     // --- Comment nodes ----------------------------------------------------
     if (isComment(child)) {
-      // Ensure trailing whitespace if last child
       if (isLast) {
         insertAfterComment(mod, child, `\n${parentIndent}`);
       }
 
-      // Format inside multi-line conditional comments
       if (isMultiLineConditional(child)) {
-        formatInsideConditionalComment(mod, child, depth + 1, indent);
+        formatInsideConditionalComment(mod, child, depth + 1, options);
       }
     }
 
@@ -223,49 +265,28 @@ function formatChildren(
 // Multi-line conditional comment formatting
 // ---------------------------------------------------------------------------
 
-/**
- * Format the HTML content inside a multi-line conditional comment.
- *
- * The comment content looks like: `[if mso]>\n<table>...\n<![endif]`
- * We extract the inner HTML, format it in a temporary HtmlMod, and
- * splice the result back into the comment.
- */
 function formatInsideConditionalComment(
   mod: HtmlMod,
   commentNode: { startIndex: number; endIndex: number; data: string },
   depth: number,
-  indent: string
+  options: ResolvedOptions
 ): void {
   const { data, startIndex, endIndex } = commentNode;
+  const { indent } = options;
 
-  // Extract the opening conditional (e.g., "[if mso]>") and closing (e.g., "<![endif]")
   const openMatch = /^\[if\s[^]*?]>/i.exec(data);
   const closeMatch = /<!\[endif]$/i.exec(data);
   if (!openMatch || !closeMatch) return;
 
   const rawInnerHtml = data.slice(openMatch[0].length, data.length - closeMatch[0].length);
-  // Trim only HTML formatting whitespace — preserve NBSP and Unicode spaces
-  const trimmedInnerHtml = rawInnerHtml.replace(/^[\t\n\f\r ]+/, '').replace(/[\t\n\f\r ]+$/, '');
+  const trimmedInnerHtml = trimFormatting(rawInnerHtml);
   if (!trimmedInnerHtml) return;
 
-  // Format the inner HTML in a scoped HtmlMod.
-  // Trim first so the formatter sees clean HTML without leading/trailing
-  // whitespace that would produce bad indentation at the top level.
-  // Pass depth - 1 because formatChildren adds 1 for children — the
-  // inner content should be indented at `depth` level (matching where
-  // the comment sits in the outer document).
   const innerMod = new HtmlMod(trimmedInnerHtml);
-  formatChildren(innerMod, innerMod.__dom.children as Iterable<SourceElement | SourceText>, depth - 1, indent);
+  formatChildren(innerMod, innerMod.__dom.children as Iterable<SourceElement | SourceText>, depth - 1, options);
 
-  // Align the close tag (<![endif]) with the open tag (<!--[if).
-  // The caller passes `depth + 1`, so `depth` here equals the comment's
-  // own indentation level in the outer document.
   const commentIndent = indent.repeat(Math.max(0, depth));
 
-  // When formatChildren was a no-op (e.g. closing tags like </td></tr></table>
-  // which htmlparser2 parses as text), re-indent every line to the comment's
-  // level.  Otherwise strip only the leading newline (formatChildren inserts
-  // one before the first child) but keep the indent.
   const innerFormatted =
     innerMod.__source === trimmedInnerHtml
       ? trimmedInnerHtml
@@ -279,11 +300,8 @@ function formatInsideConditionalComment(
   const newData = `${openMatch[0]}${formatted}${closeMatch[0]}`;
   if (newData === data) return;
 
-  // Overwrite the comment content in the source string.
-  // Comment source in htmlparser2: <!--DATA-->
-  // startIndex points to '<', data starts at startIndex + 4 (after '<!--')
   const dataStart = startIndex + 4;
-  const dataEnd = endIndex - 2; // before '-->'
+  const dataEnd = endIndex - 2;
   const oldLength = dataEnd - dataStart;
   const { length: newLength } = newData;
 
@@ -291,14 +309,119 @@ function formatInsideConditionalComment(
 
   const delta = newLength - oldLength;
 
-  // Shift sibling nodes BEFORE touching the comment itself.
   if (delta !== 0) {
     shiftPositionsAfter(mod.__dom.children, endIndex + 1, delta);
   }
 
-  // Now update the comment node itself.
   commentNode.data = newData;
   commentNode.endIndex += delta;
+}
+
+// ---------------------------------------------------------------------------
+// Attribute wrapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap attributes on opening tags that exceed `maxLineLength`.
+ * Breaks before each attribute onto a new line — saves one character
+ * compared to breaking after, and keeps lines short without adding
+ * a space character:
+ * ```
+ * <p
+ *   style="margin:1em 0">
+ * ```
+ *
+ * Uses regex on the source string after structural formatting.
+ */
+function wrapLongAttributes(mod: HtmlMod, options: ResolvedOptions): void {
+  const { maxLineLength, wrapAttributes, indent } = options;
+
+  // Match opening tags with attributes: <tagname attr1="val" attr2="val" ...>
+  // Captures: (1) tag start `<tagname`, (2) attributes block, (3) closing `>` or `/>`
+  const openTagRegex = /(<[a-z][\da-z-]*)((?:\s+[^\s/=>]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]*))?)+)(\s*\/?>)/gi;
+
+  let newSource = mod.__source;
+  let offset = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  for (const match of mod.__source.matchAll(openTagRegex)) {
+    const fullMatch = match[0];
+    const tagStart = match[1]; // e.g. "<p"
+    const attributesPart = match[2]; // e.g. ' class="x" style="y"'
+    const closing = match[3]; // e.g. ">" or " />"
+    const matchIndex = match.index;
+
+    // Calculate the line this tag starts on to get indentation
+    const lineStart = mod.__source.lastIndexOf('\n', matchIndex) + 1;
+    const leadingWhitespace = mod.__source.slice(lineStart, matchIndex);
+    const tagLineLength = leadingWhitespace.length + fullMatch.length;
+
+    // For 'auto' mode, skip tags that fit on one line
+    if (wrapAttributes === 'auto' && tagLineLength <= maxLineLength) {
+      continue;
+    }
+
+    // Parse individual attributes
+    const attributes: string[] = [];
+    const attributeRegex = /\s+([^\s/=>]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]*))?)/g;
+    let attributeMatch;
+    while ((attributeMatch = attributeRegex.exec(attributesPart)) !== null) {
+      attributes.push(attributeMatch[1]);
+    }
+
+    if (attributes.length === 0) continue;
+
+    // Build wrapped replacement
+    let replacement: string;
+    if (wrapAttributes === 'force-aligned') {
+      const alignIndent = ' '.repeat(leadingWhitespace.length + tagStart.length + 1);
+      replacement = `${tagStart} ${attributes[0]}`;
+      for (let attributeIndex = 1; attributeIndex < attributes.length; attributeIndex++) {
+        replacement += `\n${alignIndent}${attributes[attributeIndex]}`;
+      }
+      replacement += closing;
+    } else {
+      const attributeIndent = leadingWhitespace + indent;
+      replacement = tagStart;
+      for (const attribute of attributes) {
+        replacement += `\n${attributeIndent}${attribute}`;
+      }
+      replacement += closing;
+    }
+
+    // Apply replacement at shifted position
+    const shiftedIndex = matchIndex + offset;
+    newSource = newSource.slice(0, shiftedIndex) + replacement + newSource.slice(shiftedIndex + fullMatch.length);
+    offset += replacement.length - fullMatch.length;
+  }
+
+  if (newSource !== mod.__source) {
+    const fresh = new HtmlMod(newSource, mod.__options);
+    mod.__source = fresh.__source;
+    mod.__dom = fresh.__dom;
+    mod.__astUpdater = fresh.__astUpdater;
+    mod.__cachedInnerHTML = new WeakMap();
+    mod.__cachedOuterHTML = new WeakMap();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Whitespace collapsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Collapse runs of 2+ consecutive blank lines into a single blank line.
+ */
+function collapseConsecutiveBlankLines(mod: HtmlMod): void {
+  const collapsed = mod.__source.replaceAll(/\n{3,}/g, '\n\n');
+  if (collapsed !== mod.__source) {
+    const fresh = new HtmlMod(collapsed, mod.__options);
+    mod.__source = fresh.__source;
+    mod.__dom = fresh.__dom;
+    mod.__astUpdater = fresh.__astUpdater;
+    mod.__cachedInnerHTML = new WeakMap();
+    mod.__cachedOuterHTML = new WeakMap();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -312,10 +435,8 @@ function setTextContent(mod: HtmlMod, textNode: SourceText, content: string): vo
 }
 
 function insertBeforeIfNeeded(mod: HtmlMod, element: SourceElement, whitespace: string): void {
-  // Check if there's already whitespace before this element
   const charBefore = mod.__source[element.source.openTag.startIndex - 1];
   if (charBefore === '>' || charBefore === undefined) {
-    // No whitespace — insert via element wrapper
     const wrapper = new HtmlModElement(element, mod);
     wrapper.before(whitespace);
   }
@@ -352,7 +473,6 @@ function insertAfterComment(
   const charAfter = mod.__source[endPos];
   if (charAfter === '<' || charAfter === undefined) {
     mod.__appendRight(endPos, whitespace);
-    // Shift nodes after
     shiftPositionsAfter(mod.__dom.children, endPos, whitespace.length);
   }
 }
@@ -373,7 +493,6 @@ function hasInlineBlockStyle(node: SourceChildNode): boolean {
   if (!isTag(node)) return false;
   const { attribs } = node as SourceElement;
   if (!attribs) return false;
-  // Case-insensitive attribute lookup to handle lowerCaseAttributeNames: false
   const styleKey = Object.keys(attribs).find(k => k.toLowerCase() === 'style');
   const style = styleKey ? attribs[styleKey] : '';
   return /display\s*:\s*inline-block/i.test(style);
@@ -389,11 +508,6 @@ function isBubbleCloseData(data: string): boolean {
   return /\[endif]/i.test(data) && data.startsWith('<!');
 }
 
-/**
- * Whether a string contains only HTML formatting whitespace (tab, newline,
- * form-feed, carriage return, space).  Does NOT match \u00A0 (NBSP) or
- * other Unicode spaces — those are semantic content.
- */
 function isWhitespaceOnly(string_: string): boolean {
   return /^[\t\n\f\r ]*$/.test(string_);
 }
@@ -403,11 +517,6 @@ function trimFormatting(string_: string): string {
   return string_.replace(/^[\t\n\f\r ]+/, '').replace(/[\t\n\f\r ]+$/, '');
 }
 
-/**
- * Trim only HTML formatting whitespace (tab, newline, form-feed, carriage
- * return, space) from the start and end of the document.  Unlike JS
- * String.trim(), this preserves NBSP and other Unicode spaces.
- */
 function trimFormattingWhitespace(mod: HtmlMod): void {
   const leadingMatch = /^[\t\n\f\r ]+/.exec(mod.__source);
   if (leadingMatch) {
@@ -426,7 +535,6 @@ function isMultiLineConditional(node: { data?: string }): boolean {
   const { data } = node;
   if (!/^\[if\s/i.test(data)) return false;
   if (!/\[endif]$/i.test(data)) return false;
-  // Extract inner content
   const openMatch = /^\[if\s[^]*?]>/i.exec(data);
   if (!openMatch) return false;
   const closeMatch = /<!\[endif]$/i.exec(data);
@@ -435,16 +543,6 @@ function isMultiLineConditional(node: { data?: string }): boolean {
   return inner.includes('\n');
 }
 
-/**
- * Build a set of child indices that are protected by single-line bubble
- * conditional comment pairs.  Walks the sibling list to find bubble open
- * comments (data matches `[if ...`), then checks if the matching close
- * (data matches `[endif]`) appears without any newlines in between.
- * Only the indices between a matched single-line pair are protected.
- *
- * This per-sibling-list approach means a single-line bubble doesn't
- * accidentally protect a later multi-line bubble with the same data.
- */
 function buildProtectedBubbleIndices(childArray: Array<SourceElement | SourceText | SourceChildNode>): Set<number> {
   const protectedSet = new Set<number>();
 
@@ -452,16 +550,12 @@ function buildProtectedBubbleIndices(childArray: Array<SourceElement | SourceTex
     const node = childArray[index];
     if (!isComment(node)) continue;
     const data = (node as { data?: string }).data ?? '';
-    // Bubble open comments end with "><!": <!--[if !mso]><!-->
-    // Downlevel-hidden comments contain the full content and end with <![endif]
     if (!isBubbleOpenData(data)) continue;
 
-    // Found a bubble open — scan forward for the matching close
     let hasNewline = false;
     for (let after = index + 1; after < childArray.length; after++) {
       const sibling = childArray[after];
 
-      // Check for newlines in text nodes between open and close
       if (isText(sibling) && (sibling as SourceText).data.includes('\n')) {
         hasNewline = true;
       }
@@ -469,7 +563,6 @@ function buildProtectedBubbleIndices(childArray: Array<SourceElement | SourceTex
       if (isComment(sibling)) {
         const siblingData = (sibling as { data?: string }).data ?? '';
         if (isBubbleCloseData(siblingData)) {
-          // Found matching close — protect everything between if single-line
           if (!hasNewline) {
             for (let protect = index; protect <= after; protect++) {
               protectedSet.add(protect);
@@ -478,7 +571,6 @@ function buildProtectedBubbleIndices(childArray: Array<SourceElement | SourceTex
           break;
         }
         if (isBubbleOpenData(siblingData)) {
-          // Hit another open before finding close — stop
           break;
         }
       }
@@ -509,14 +601,9 @@ interface AstNode {
   };
 }
 
-/**
- * After a raw string mutation, shift all AST node positions that come
- * after `afterPos` by `delta` characters.
- */
 function shiftPositionsAfter(nodes: Iterable<AstNode>, afterPos: number, delta: number): void {
   for (const node of nodes) {
     if (node.startIndex == null || node.endIndex == null) {
-      // Recurse into children even if this node has no position
       if (node.children) {
         shiftPositionsAfter(node.children, afterPos, delta);
       }
@@ -527,7 +614,6 @@ function shiftPositionsAfter(nodes: Iterable<AstNode>, afterPos: number, delta: 
       node.startIndex += delta;
       node.endIndex += delta;
 
-      // For tag elements, shift source positions too
       if (node.source?.openTag) {
         node.source.openTag.startIndex += delta;
         node.source.openTag.endIndex += delta;
@@ -547,7 +633,6 @@ function shiftPositionsAfter(nodes: Iterable<AstNode>, afterPos: number, delta: 
         }
       }
     } else if (node.endIndex >= afterPos) {
-      // Node spans the edit point — only shift endIndex
       node.endIndex += delta;
       if (node.source?.closeTag && node.source.closeTag.startIndex >= afterPos) {
         node.source.closeTag.startIndex += delta;
@@ -555,7 +640,6 @@ function shiftPositionsAfter(nodes: Iterable<AstNode>, afterPos: number, delta: 
       }
     }
 
-    // Recurse into children
     if (node.children) {
       shiftPositionsAfter(node.children, afterPos, delta);
     }

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -132,19 +132,15 @@ function formatChildren(
       } else if (isComment(child)) {
         insertBeforeComment(mod, child, `\n${childIndent}`);
       }
-    } else if (previous && !isText(previous)) {
-      // Two non-text nodes directly adjacent.  Insert whitespace between
-      // them UNLESS both are <div>s — adjacent divs are commonly used as
-      // display:inline-block columns in email where any whitespace breaks
-      // the layout.
-      const previousIsDiv = isTag(previous) && (previous as SourceElement).tagName === 'div';
-      const currentIsDiv = isTag(child) && (child as SourceElement).tagName === 'div';
-      if (!(previousIsDiv && currentIsDiv)) {
-        if (isTag(previous)) {
-          insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
-        } else if (isComment(previous)) {
-          insertAfterComment(mod, previous, `\n${childIndent}`);
-        }
+    } else if (previous && !isText(previous) && !hasInlineBlockStyle(previous) && !hasInlineBlockStyle(child)) {
+      // Two non-text nodes directly adjacent — insert whitespace between
+      // them.  Skip when either has display:inline-block — adjacent
+      // inline-block elements are a common email column pattern where
+      // any added whitespace breaks the layout on iOS/Android.
+      if (isTag(previous)) {
+        insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
+      } else if (isComment(previous)) {
+        insertAfterComment(mod, previous, `\n${childIndent}`);
       }
     }
 
@@ -337,6 +333,12 @@ function isInline(element: SourceElement): boolean {
 
 function isPreserved(element: SourceElement): boolean {
   return PRESERVE_CONTENT.has(element.tagName);
+}
+
+function hasInlineBlockStyle(node: unknown): boolean {
+  if (!isTag(node)) return false;
+  const style = (node as SourceElement).attribs?.style ?? '';
+  return /display\s*:\s*inline-block/i.test(style);
 }
 
 function isWhitespaceOnly(string_: string): boolean {

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -98,9 +98,9 @@ function formatChildren(
 
   // Determine if this list contains any block-level elements.
   // If it's all inline / text / comments we leave it alone.
-  const hasBlock = childArray.some(
-    child => isTag(child) && !isInline(child as SourceElement) && !isPreserved(child as SourceElement)
-  );
+  // Preserved elements (pre, code, textarea) count as block — we format
+  // whitespace *around* them, just not inside them.
+  const hasBlock = childArray.some(child => isTag(child) && !isInline(child as SourceElement));
 
   if (!hasBlock) return;
 
@@ -125,21 +125,26 @@ function formatChildren(
     }
 
     // --- Ensure leading whitespace before any non-text node ---------------
-    // If there's no text node before this child (either it's the first
-    // child, or the previous sibling is also a tag/comment), insert one.
     if (isFirst) {
+      // First child — insert whitespace after parent open tag.
       if (isTag(child)) {
         insertBeforeIfNeeded(mod, child as SourceElement, `\n${childIndent}`);
       } else if (isComment(child)) {
         insertBeforeComment(mod, child, `\n${childIndent}`);
       }
     } else if (previous && !isText(previous)) {
-      // Two non-text nodes adjacent — insert whitespace between them.
-      // Use the previous node's end position to insert after it.
-      if (isTag(previous)) {
-        insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
-      } else if (isComment(previous)) {
-        insertAfterComment(mod, previous, `\n${childIndent}`);
+      // Two non-text nodes directly adjacent.  Insert whitespace between
+      // them UNLESS both are <div>s — adjacent divs are commonly used as
+      // display:inline-block columns in email where any whitespace breaks
+      // the layout.
+      const previousIsDiv = isTag(previous) && (previous as SourceElement).tagName === 'div';
+      const currentIsDiv = isTag(child) && (child as SourceElement).tagName === 'div';
+      if (!(previousIsDiv && currentIsDiv)) {
+        if (isTag(previous)) {
+          insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
+        } else if (isComment(previous)) {
+          insertAfterComment(mod, previous, `\n${childIndent}`);
+        }
       }
     }
 
@@ -249,15 +254,21 @@ function formatInsideConditionalComment(
 
   mod.__source = mod.__source.slice(0, dataStart) + newData + mod.__source.slice(dataStart + oldLength);
 
-  // Update the comment node and track the delta
   const delta = newLength - oldLength;
-  commentNode.data = newData;
-  commentNode.endIndex += delta;
 
-  // Shift all nodes after this comment
+  // Shift sibling nodes BEFORE touching the comment itself.
+  // shiftPositionsAfter uses `endIndex + 1` as boundary — at this point
+  // commentNode.endIndex is still the original value, so the walk won't
+  // match the comment in the `startIndex >= afterPos` branch and can
+  // only hit the `endIndex >= afterPos` branch.  But we're about to
+  // set endIndex ourselves, so shift first to avoid double-counting.
   if (delta !== 0) {
     shiftPositionsAfter(mod.__dom.children, endIndex + 1, delta);
   }
+
+  // Now update the comment node itself.
+  commentNode.data = newData;
+  commentNode.endIndex += delta;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -140,18 +140,19 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
     wrapLongAttributes(mod, resolved);
   }
 
+  // Re-sync AST after formatting + wrapping.  formatChildren uses a mix of
+  // AST-aware ops (HtmlModElement.before/after) and raw string ops (for
+  // comments/directives) that track deltas but don't create text nodes.
+  // wrapLongAttributes rewrites opening tags.  Re-parsing here ensures
+  // positions are valid for collapse/trim, and that any HtmlModElement
+  // handles captured before prettify() are detached cleanly.
+  resetHtmlMod(mod, mod.__source);
+
   if (resolved.collapseBlankLines) {
     collapseConsecutiveBlankLines(mod);
   }
 
   trimFormattingWhitespace(mod);
-
-  // Re-sync the AST to match the final source.  Formatting uses a mix of
-  // AST-aware operations (HtmlModElement.before/after, HtmlModText.innerHTML)
-  // and raw string operations (for comments/directives).  The raw operations
-  // track position deltas but don't create/remove AST text nodes.  A final
-  // re-parse ensures the AST is fully consistent for downstream consumers.
-  resetHtmlMod(mod, mod.__source);
 
   return mod;
 }
@@ -381,9 +382,14 @@ function wrapLongAttributes(mod: HtmlMod, options: ResolvedOptions): void {
     const lastAttributeEnd = element.source.attributes.at(-1)!.source.endIndex + 1;
     const closing = openTagSource.slice(lastAttributeEnd - startIndex);
 
-    // Build replacement
+    // Derive indentation from the whitespace-only prefix on this line.
+    // If the tag starts mid-line (e.g. <p>Hello <a ...), the prefix
+    // contains non-whitespace content — skip wrapping for inline tags
+    // that don't start at the beginning of a line.
     const lineStart = newSource.lastIndexOf('\n', startIndex) + 1;
-    const leadingWhitespace = newSource.slice(lineStart, startIndex);
+    const linePrefix = newSource.slice(lineStart, startIndex);
+    if (!/^[\t ]*$/.test(linePrefix)) continue;
+    const leadingWhitespace = linePrefix;
 
     let replacement: string;
     if (wrapAttributes === 'force-aligned') {

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -1,4 +1,3 @@
-import findConditionalComments from '@ciolabs/html-find-conditional-comments';
 import { HtmlMod, HtmlModElement, HtmlModText } from '@ciolabs/html-mod';
 import type { SourceElement, SourceText, SourceChildNode } from '@ciolabs/htmlparser2-source';
 import { isComment, isDirective, isTag, isText } from '@ciolabs/htmlparser2-source';
@@ -78,18 +77,13 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
   const mod = typeof input === 'string' ? new HtmlMod(input) : input;
   const indent = (options?.indentChar ?? ' ').repeat(options?.indentSize ?? 2);
 
-  // Collect comment data strings for single-line bubble/revealed
-  // conditionals.  Position-independent — survives formatting mutations.
-  const bubbleCommentData = buildSingleLineBubbleCommentData(mod.__source);
-
   // Format the document tree.
   // Depth -1 so that top-level elements sit at indent 0.
-  formatChildren(mod, mod.__dom.children as Iterable<SourceElement | SourceText>, -1, indent, bubbleCommentData);
+  formatChildren(mod, mod.__dom.children as Iterable<SourceElement | SourceText>, -1, indent);
 
-  // Trim trailing whitespace on the document
-  mod.trimEnd();
-  // Trim leading empty lines
-  mod.trimStart();
+  // Trim only HTML formatting whitespace at document boundaries.
+  // Preserve NBSP (\u00A0) and other semantic Unicode spaces.
+  trimFormattingWhitespace(mod);
 
   return mod;
 }
@@ -107,8 +101,7 @@ function formatChildren(
   mod: HtmlMod,
   children: Iterable<SourceElement | SourceText>,
   depth: number,
-  indent: string,
-  bubbleCommentData: Set<string>
+  indent: string
 ): void {
   const childArray = [...children];
 
@@ -126,11 +119,10 @@ function formatChildren(
 
   if (!hasBlock) return;
 
-  // Check if any sibling is a bubble comment — if so, text nodes between
-  // bubble comment pairs are protected (position-independent check).
-  const hasBubbleSibling = childArray.some(
-    child => isComment(child) && bubbleCommentData.has((child as { data?: string }).data ?? '')
-  );
+  // Build a set of child indices that are protected by single-line bubble
+  // conditional pairs.  Computed per sibling list so a single-line bubble
+  // doesn't accidentally protect a multi-line bubble later in the same list.
+  const protectedIndices = buildProtectedBubbleIndices(childArray);
 
   const childIndent = indent.repeat(Math.max(0, depth + 1));
   const parentIndent = indent.repeat(Math.max(0, depth));
@@ -145,7 +137,7 @@ function formatChildren(
     // In a block context, normalize whitespace-only text nodes to the
     // correct indentation regardless of what follows (block or inline).
     // Skip when:
-    // - The text sits between bubble comment pairs (single-line conditional)
+    // - The index is protected by a single-line bubble conditional pair
     // - The text separates two display:inline-block elements (column gap)
     if (isText(child)) {
       const textNode = child as SourceText;
@@ -153,11 +145,7 @@ function formatChildren(
       const betweenInlineBlocks =
         previous && nextSibling && hasInlineBlockStyle(previous) && hasInlineBlockStyle(nextSibling);
 
-      if (
-        isWhitespaceOnly(textNode.data) &&
-        !betweenInlineBlocks &&
-        !(hasBubbleSibling && isTextBetweenBubbleComments(index, childArray, bubbleCommentData))
-      ) {
+      if (isWhitespaceOnly(textNode.data) && !betweenInlineBlocks && !protectedIndices.has(index)) {
         setTextContent(mod, textNode, `\n${isLast ? parentIndent : childIndent}`);
       }
       continue;
@@ -175,13 +163,12 @@ function formatChildren(
       previous &&
       !isText(previous) &&
       !(hasInlineBlockStyle(previous) && hasInlineBlockStyle(child)) &&
-      !isBubbleCommentBoundary(previous, child, bubbleCommentData)
+      !protectedIndices.has(index)
     ) {
       // Two non-text nodes directly adjacent — insert whitespace between
       // them.  Skip when:
       // - BOTH are display:inline-block (email column pattern)
-      // - Either node is a comment belonging to a single-line bubble
-      //   conditional (e.g. <!--[if !mso]><!-->...<![endif]-->)
+      // - The index is protected by a single-line bubble conditional pair
       if (isTag(previous)) {
         insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
       } else if (isComment(previous) || isDirective(previous)) {
@@ -203,13 +190,7 @@ function formatChildren(
 
       // Recurse into children (unless content is preserved)
       if (!isPreserved(element) && element.children.length > 0) {
-        formatChildren(
-          mod,
-          element.children as Iterable<SourceElement | SourceText>,
-          depth + 1,
-          indent,
-          bubbleCommentData
-        );
+        formatChildren(mod, element.children as Iterable<SourceElement | SourceText>, depth + 1, indent);
       }
 
       // Ensure trailing whitespace if last child
@@ -273,14 +254,7 @@ function formatInsideConditionalComment(
   // inner content should be indented at `depth` level (matching where
   // the comment sits in the outer document).
   const innerMod = new HtmlMod(trimmedInnerHtml);
-  const innerBubbleData = buildSingleLineBubbleCommentData(trimmedInnerHtml);
-  formatChildren(
-    innerMod,
-    innerMod.__dom.children as Iterable<SourceElement | SourceText>,
-    depth - 1,
-    indent,
-    innerBubbleData
-  );
+  formatChildren(innerMod, innerMod.__dom.children as Iterable<SourceElement | SourceText>, depth - 1, indent);
 
   // Align the close tag (<![endif]) with the open tag (<!--[if).
   // The caller passes `depth + 1`, so `depth` here equals the comment's
@@ -400,6 +374,16 @@ function hasInlineBlockStyle(node: SourceChildNode): boolean {
   return /display\s*:\s*inline-block/i.test(style);
 }
 
+/** Bubble open comment data ends with `><!`: e.g. `[if !mso]><!` */
+function isBubbleOpenData(data: string): boolean {
+  return /\[if\s/i.test(data) && data.endsWith('><!');
+}
+
+/** Bubble close comment data: e.g. `<![endif]` */
+function isBubbleCloseData(data: string): boolean {
+  return /\[endif]/i.test(data) && data.startsWith('<!');
+}
+
 /**
  * Whether a string contains only HTML formatting whitespace (tab, newline,
  * form-feed, carriage return, space).  Does NOT match \u00A0 (NBSP) or
@@ -407,6 +391,24 @@ function hasInlineBlockStyle(node: SourceChildNode): boolean {
  */
 function isWhitespaceOnly(string_: string): boolean {
   return /^[\t\n\f\r ]*$/.test(string_);
+}
+
+/**
+ * Trim only HTML formatting whitespace (tab, newline, form-feed, carriage
+ * return, space) from the start and end of the document.  Unlike JS
+ * String.trim(), this preserves NBSP and other Unicode spaces.
+ */
+function trimFormattingWhitespace(mod: HtmlMod): void {
+  const leadingMatch = /^[\t\n\f\r ]+/.exec(mod.__source);
+  if (leadingMatch) {
+    mod.__source = mod.__source.slice(leadingMatch[0].length);
+    shiftPositionsAfter(mod.__dom.children, 0, -leadingMatch[0].length);
+  }
+
+  const trailingMatch = /[\t\n\f\r ]+$/.exec(mod.__source);
+  if (trailingMatch) {
+    mod.__source = mod.__source.slice(0, -trailingMatch[0].length);
+  }
 }
 
 function isMultiLineConditional(node: { data?: string }): boolean {
@@ -424,120 +426,56 @@ function isMultiLineConditional(node: { data?: string }): boolean {
 }
 
 /**
- * Check whether a text node at `index` in `childArray` sits between
- * an open and close comment that form a single-line bubble conditional.
+ * Build a set of child indices that are protected by single-line bubble
+ * conditional comment pairs.  Walks the sibling list to find bubble open
+ * comments (data matches `[if ...`), then checks if the matching close
+ * (data matches `[endif]`) appears without any newlines in between.
+ * Only the indices between a matched single-line pair are protected.
  *
- * Tracks matched pairs so two separate conditionals in the same list
- * don't falsely protect the gap between them.  Open comments have data
- * containing `[if` and close comments have data containing `[endif]`.
+ * This per-sibling-list approach means a single-line bubble doesn't
+ * accidentally protect a later multi-line bubble with the same data.
  */
-function isTextBetweenBubbleComments(
-  index: number,
-  childArray: Array<SourceElement | SourceText | SourceChildNode>,
-  bubbleData: Set<string>
-): boolean {
-  // Scan backwards for the nearest bubble OPEN comment (data has "[if")
-  let foundOpen = false;
-  for (let before = index - 1; before >= 0; before--) {
-    const node = childArray[before];
+function buildProtectedBubbleIndices(childArray: Array<SourceElement | SourceText | SourceChildNode>): Set<number> {
+  const protectedSet = new Set<number>();
+
+  for (let index = 0; index < childArray.length; index++) {
+    const node = childArray[index];
     if (!isComment(node)) continue;
     const data = (node as { data?: string }).data ?? '';
-    if (!bubbleData.has(data)) continue;
+    // Bubble open comments end with "><!": <!--[if !mso]><!-->
+    // Downlevel-hidden comments contain the full content and end with <![endif]
+    if (!isBubbleOpenData(data)) continue;
 
-    if (/\[if\s/i.test(data)) {
-      // Found an open — but only if there's no close between it and us
-      // (which would mean a complete conditional before our text node)
-      foundOpen = true;
-      break;
+    // Found a bubble open — scan forward for the matching close
+    let hasNewline = false;
+    for (let after = index + 1; after < childArray.length; after++) {
+      const sibling = childArray[after];
+
+      // Check for newlines in text nodes between open and close
+      if (isText(sibling) && (sibling as SourceText).data.includes('\n')) {
+        hasNewline = true;
+      }
+
+      if (isComment(sibling)) {
+        const siblingData = (sibling as { data?: string }).data ?? '';
+        if (isBubbleCloseData(siblingData)) {
+          // Found matching close — protect everything between if single-line
+          if (!hasNewline) {
+            for (let protect = index; protect <= after; protect++) {
+              protectedSet.add(protect);
+            }
+          }
+          break;
+        }
+        if (isBubbleOpenData(siblingData)) {
+          // Hit another open before finding close — stop
+          break;
+        }
+      }
     }
-    if (/\[endif]/i.test(data)) {
-      // Hit a close comment before finding an open — we're outside
-      return false;
-    }
-  }
-  if (!foundOpen) return false;
-
-  // Scan forwards for the matching bubble CLOSE comment (data has "[endif]")
-  for (let after = index + 1; after < childArray.length; after++) {
-    const node = childArray[after];
-    if (!isComment(node)) continue;
-    const data = (node as { data?: string }).data ?? '';
-    if (!bubbleData.has(data)) continue;
-
-    if (/\[endif]/i.test(data)) {
-      return true;
-    }
-    if (/\[if\s/i.test(data)) {
-      // Hit a new open before finding the close — we're outside
-      return false;
-    }
-  }
-  return false;
-}
-
-/**
- * Check whether two adjacent non-text nodes are both inside the same
- * single-line bubble conditional.  Returns true only when:
- * - nodeA is a bubble open comment and nodeB is content after it, OR
- * - nodeA is content and nodeB is a bubble close comment
- *
- * Does NOT protect the gap between a close and a subsequent open —
- * that's between two separate conditionals and should be formatted.
- */
-function isBubbleCommentBoundary(
-  nodeA: SourceElement | SourceText | SourceChildNode,
-  nodeB: SourceElement | SourceText | SourceChildNode,
-  bubbleData: Set<string>
-): boolean {
-  if (bubbleData.size === 0) return false;
-
-  // nodeA is a bubble open → nodeB is inside the conditional
-  if (isComment(nodeA)) {
-    const data = (nodeA as { data?: string }).data ?? '';
-    if (bubbleData.has(data) && /\[if\s/i.test(data)) return true;
   }
 
-  // nodeB is a bubble close → nodeA is inside the conditional
-  if (isComment(nodeB)) {
-    const data = (nodeB as { data?: string }).data ?? '';
-    if (bubbleData.has(data) && /\[endif]/i.test(data)) return true;
-  }
-
-  return false;
-}
-
-// ---------------------------------------------------------------------------
-// Single-line bubble conditional comment detection
-// ---------------------------------------------------------------------------
-
-/**
- * Collect the comment data strings for comments that form single-line
- * bubble/revealed conditionals.  For `<!--[if !mso]><!-->...<![endif]-->`,
- * the opening comment has data `[if !mso]><!` and the closing comment
- * has data `<![endif]`.  Both are added to the set.
- *
- * These are used for position-independent checks that survive source
- * mutations during formatting.
- */
-function buildSingleLineBubbleCommentData(html: string): Set<string> {
-  const comments = findConditionalComments(html);
-  const dataSet = new Set<string>();
-
-  for (const comment of comments) {
-    if (!comment.bubble) continue;
-    const content = html.slice(comment.range[0] + comment.open.length, comment.range[1] - comment.close.length);
-    if (content.includes('\n')) continue;
-
-    // Extract the comment data from the open and close strings.
-    // <!--[if !mso]><!--> has comment data "[if !mso]><!"
-    // <!--<![endif]--> has comment data "<![endif]"
-    const openData = comment.open.slice(4, -3); // strip "<!--" and "-->"
-    const closeData = comment.close.slice(4, -3); // strip "<!--" and "-->"
-    if (openData) dataSet.add(openData);
-    if (closeData) dataSet.add(closeData);
-  }
-
-  return dataSet;
+  return protectedSet;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -364,8 +364,8 @@ function buildSingleLineConditionalRanges(html: string): Array<[number, number]>
 // ---------------------------------------------------------------------------
 
 interface AstNode {
-  startIndex: number;
-  endIndex: number;
+  startIndex: number | null;
+  endIndex: number | null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   children?: Iterable<any>;
   data?: string;
@@ -386,6 +386,14 @@ interface AstNode {
  */
 function shiftPositionsAfter(nodes: Iterable<AstNode>, afterPos: number, delta: number): void {
   for (const node of nodes) {
+    if (node.startIndex == null || node.endIndex == null) {
+      // Recurse into children even if this node has no position
+      if (node.children) {
+        shiftPositionsAfter(node.children, afterPos, delta);
+      }
+      continue;
+    }
+
     if (node.startIndex >= afterPos) {
       node.startIndex += delta;
       node.endIndex += delta;

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -1,7 +1,7 @@
 import findConditionalComments from '@ciolabs/html-find-conditional-comments';
 import { HtmlMod, HtmlModElement, HtmlModText } from '@ciolabs/html-mod';
 import type { SourceElement, SourceText, SourceChildNode } from '@ciolabs/htmlparser2-source';
-import { isComment, isTag, isText } from '@ciolabs/htmlparser2-source';
+import { isComment, isDirective, isTag, isText } from '@ciolabs/htmlparser2-source';
 
 /**
  * Inline HTML elements — we never add newlines around these.
@@ -118,7 +118,10 @@ function formatChildren(
   // whitespace *around* them, just not inside them.
   // Multi-line conditional comments also count — they need internal formatting.
   const hasBlock = childArray.some(
-    child => (isTag(child) && !isInline(child as SourceElement)) || (isComment(child) && isMultiLineConditional(child))
+    child =>
+      (isTag(child) && !isInline(child as SourceElement)) ||
+      (isComment(child) && isMultiLineConditional(child)) ||
+      isDirective(child)
   );
 
   if (!hasBlock) return;
@@ -159,7 +162,7 @@ function formatChildren(
       // First child — insert whitespace after parent open tag.
       if (isTag(child)) {
         insertBeforeIfNeeded(mod, child as SourceElement, `\n${childIndent}`);
-      } else if (isComment(child)) {
+      } else if (isComment(child) || isDirective(child)) {
         insertBeforeComment(mod, child, `\n${childIndent}`);
       }
     } else if (
@@ -175,7 +178,7 @@ function formatChildren(
       //   conditional (e.g. <!--[if !mso]><!-->...<![endif]-->)
       if (isTag(previous)) {
         insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
-      } else if (isComment(previous)) {
+      } else if (isComment(previous) || isDirective(previous)) {
         insertAfterComment(mod, previous, `\n${childIndent}`);
       }
     }
@@ -221,6 +224,11 @@ function formatChildren(
         formatInsideConditionalComment(mod, child, depth + 1, indent);
       }
     }
+
+    // --- Directive nodes (<!DOCTYPE html>, etc.) --------------------------
+    if (isDirective(child) && isLast) {
+      insertAfterComment(mod, child, `\n${parentIndent}`);
+    }
   }
 }
 
@@ -244,8 +252,8 @@ function formatInsideConditionalComment(
   const { data, startIndex, endIndex } = commentNode;
 
   // Extract the opening conditional (e.g., "[if mso]>") and closing (e.g., "<![endif]")
-  const openMatch = /^\[if\s[^]*?]>/.exec(data);
-  const closeMatch = /<!\[endif]$/.exec(data);
+  const openMatch = /^\[if\s[^]*?]>/i.exec(data);
+  const closeMatch = /<!\[endif]$/i.exec(data);
   if (!openMatch || !closeMatch) return;
 
   const rawInnerHtml = data.slice(openMatch[0].length, data.length - closeMatch[0].length);
@@ -393,12 +401,14 @@ function isWhitespaceOnly(string_: string): boolean {
 function isMultiLineConditional(node: { data?: string }): boolean {
   if (!node.data) return false;
   const { data } = node;
-  if (!data.startsWith('[if ')) return false;
-  if (!data.endsWith('<![endif]')) return false;
+  if (!/^\[if\s/i.test(data)) return false;
+  if (!/\[endif]$/i.test(data)) return false;
   // Extract inner content
-  const openMatch = /^\[if\s[^]*?]>/.exec(data);
+  const openMatch = /^\[if\s[^]*?]>/i.exec(data);
   if (!openMatch) return false;
-  const inner = data.slice(openMatch[0].length, data.length - '<![endif]'.length);
+  const closeMatch = /<!\[endif]$/i.exec(data);
+  if (!closeMatch) return false;
+  const inner = data.slice(openMatch[0].length, data.length - closeMatch[0].length);
   return inner.includes('\n');
 }
 

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -458,14 +458,17 @@ function collapseConsecutiveBlankLines(mod: HtmlMod): void {
 }
 
 /**
- * Collect source ranges of content inside preserved elements (pre, code,
- * textarea).  Scans the raw source string directly — works regardless of
- * whether the AST is synced, and catches preserved elements inside
- * conditional comments (which are comment text to the parser).
+ * Collect source ranges of content that must not be modified by
+ * post-processing (collapse, trim).  Includes:
+ * - Whitespace-preserved elements: pre, code, textarea
+ * - Raw-text elements: script, style
+ *
+ * Scans the raw source string directly — works regardless of whether the
+ * AST is synced, and catches elements inside conditional comments.
  */
 function buildPreservedContentRanges(mod: HtmlMod): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
-  const preservedTagRegex = /<(pre|code|textarea)\b[^>]*>([\S\s]*?)<\/\1>/gi;
+  const preservedTagRegex = /<(pre|code|textarea|script|style)\b[^>]*>([\S\s]*?)<\/\1>/gi;
   for (const match of mod.__source.matchAll(preservedTagRegex)) {
     const openTagEnd = match.index + match[0].indexOf('>') + 1;
     const closeTagStart = match.index + match[0].lastIndexOf('</');

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -122,9 +122,12 @@ function resolveOptions(options?: PrettifyOptions): ResolvedOptions {
 /**
  * Format and prettify HTML email content.
  *
- * Walks the html-mod AST and adjusts whitespace text nodes in place —
- * no re-parse, no full-string rewrite.  The `HtmlMod` instance stays
- * live with valid positions throughout.
+ * Walks the html-mod AST and adjusts whitespace text nodes, then
+ * re-parses to sync the AST.  The returned `HtmlMod` has a consistent
+ * AST for further edits.
+ *
+ * **Note:** Any `HtmlModElement` handles captured before calling
+ * `prettify(mod)` will be stale — re-query after formatting.
  *
  * - If `HtmlMod`, the instance is mutated in place and returned.
  * - If `string`, a new `HtmlMod` is created, formatted, and returned.
@@ -357,8 +360,8 @@ function wrapLongAttributes(mod: HtmlMod, options: ResolvedOptions): void {
         }
       }
 
-      // Always walk children
-      if (element.children.length > 0) {
+      // Walk children unless this is a preserved element (pre/code/textarea)
+      if (!isPreserved(element) && element.children.length > 0) {
         walk(element.children as Iterable<SourceElement | SourceText | SourceChildNode>);
       }
     }
@@ -458,10 +461,14 @@ function collapseConsecutiveBlankLines(mod: HtmlMod): void {
 
 /**
  * Collect source ranges of content inside preserved elements (pre, code,
- * textarea).  Used to protect these ranges from post-processing operations.
+ * textarea).  Walks the AST and also scans the raw source with regex to
+ * catch preserved elements inside conditional comments (which are comment
+ * text to the parser, not in the AST).
  */
 function buildPreservedContentRanges(mod: HtmlMod): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
+
+  // Walk the AST for top-level preserved elements
   const walk = (nodes: Iterable<SourceElement | SourceText | SourceChildNode>) => {
     for (const node of nodes) {
       if (isTag(node)) {
@@ -477,6 +484,19 @@ function buildPreservedContentRanges(mod: HtmlMod): Array<[number, number]> {
     }
   };
   walk(mod.__dom.children as Iterable<SourceElement | SourceText | SourceChildNode>);
+
+  // Also scan raw source for preserved elements inside comments
+  // (conditional comment content is not in the AST)
+  const preservedTagRegex = /<(pre|code|textarea)\b[^>]*>([\S\s]*?)<\/\1>/gi;
+  for (const match of mod.__source.matchAll(preservedTagRegex)) {
+    const openTagEnd = match.index + match[0].indexOf('>') + 1;
+    const closeTagStart = match.index + match[0].lastIndexOf('</');
+    // Only add if not already covered by an AST range
+    if (!ranges.some(([start, end]) => openTagEnd >= start && closeTagStart <= end)) {
+      ranges.push([openTagEnd, closeTagStart]);
+    }
+  }
+
   return ranges;
 }
 

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -75,7 +75,7 @@ export interface PrettifyOptions {
  * - If `string`, a new `HtmlMod` is created, formatted, and returned.
  */
 export default function prettify(input: HtmlMod | string, options?: PrettifyOptions): HtmlMod {
-  const mod = input instanceof HtmlMod ? input : new HtmlMod(input);
+  const mod = typeof input === 'string' ? new HtmlMod(input) : input;
   const indent = (options?.indentChar ?? ' ').repeat(options?.indentSize ?? 2);
 
   // Collect comment data strings for single-line bubble/revealed
@@ -387,11 +387,11 @@ function insertAfterComment(
 // ---------------------------------------------------------------------------
 
 function isInline(element: SourceElement): boolean {
-  return INLINE_ELEMENTS.has(element.tagName);
+  return INLINE_ELEMENTS.has(element.tagName.toLowerCase());
 }
 
 function isPreserved(element: SourceElement): boolean {
-  return PRESERVE_CONTENT.has(element.tagName);
+  return PRESERVE_CONTENT.has(element.tagName.toLowerCase());
 }
 
 function hasInlineBlockStyle(node: SourceChildNode): boolean {
@@ -400,8 +400,13 @@ function hasInlineBlockStyle(node: SourceChildNode): boolean {
   return /display\s*:\s*inline-block/i.test(style);
 }
 
+/**
+ * Whether a string contains only HTML formatting whitespace (tab, newline,
+ * form-feed, carriage return, space).  Does NOT match \u00A0 (NBSP) or
+ * other Unicode spaces — those are semantic content.
+ */
 function isWhitespaceOnly(string_: string): boolean {
-  return /^\s*$/.test(string_);
+  return /^[\t\n\f\r ]*$/.test(string_);
 }
 
 function isMultiLineConditional(node: { data?: string }): boolean {

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -122,12 +122,9 @@ function resolveOptions(options?: PrettifyOptions): ResolvedOptions {
 /**
  * Format and prettify HTML email content.
  *
- * Walks the html-mod AST and adjusts whitespace text nodes, then
- * re-parses to sync the AST.  The returned `HtmlMod` has a consistent
- * AST for further edits.
- *
- * **Note:** Any `HtmlModElement` handles captured before calling
- * `prettify(mod)` will be stale — re-query after formatting.
+ * Walks the html-mod AST and adjusts whitespace text nodes in place.
+ * Attribute wrapping and blank-line collapse trigger a re-parse only
+ * when they make changes.
  *
  * - If `HtmlMod`, the instance is mutated in place and returned.
  * - If `string`, a new `HtmlMod` is created, formatted, and returned.
@@ -153,12 +150,6 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
   }
 
   trimFormattingWhitespace(mod);
-
-  // Final re-parse to sync the AST with the source.  Formatting uses a mix
-  // of AST-aware ops and raw string mutations.  Collapse and trim further
-  // mutate __source.  This ensures the returned HtmlMod has a consistent
-  // AST for downstream querySelector/textContent/innerHTML.
-  resetHtmlMod(mod, mod.__source);
 
   return mod;
 }
@@ -274,7 +265,7 @@ function formatInsideConditionalComment(
   const trimmedInnerHtml = trimFormatting(rawInnerHtml);
   if (!trimmedInnerHtml) return;
 
-  const innerMod = new HtmlMod(trimmedInnerHtml);
+  const innerMod = new HtmlMod(trimmedInnerHtml, mod.__options);
   formatChildren(innerMod, innerMod.__dom.children as Iterable<SourceElement | SourceText>, depth - 1, options);
 
   // Also wrap attributes inside the conditional comment content
@@ -446,33 +437,34 @@ function wrapLongAttributes(mod: HtmlMod, options: ResolvedOptions): void {
  * Skips content inside preserved elements (pre, code, textarea).
  */
 function collapseConsecutiveBlankLines(mod: HtmlMod): void {
-  // Build a set of character ranges to protect
   const protectedRanges = buildPreservedContentRanges(mod);
 
-  // Match 2+ consecutive blank lines — a blank line is \n followed by
-  // optional whitespace then another \n.  This catches both `\n\n\n`
-  // and `\n  \n  \n` (indented blank lines).
+  // Match 2+ consecutive blank lines (with optional indentation).
   const matches = [...mod.__source.matchAll(/\n([\t ]*\n){2,}/g)];
   if (matches.length === 0) return;
 
-  // Process from end to start so positions stay valid
-  for (let index = matches.length - 1; index >= 0; index--) {
-    const match = matches[index];
+  let newSource = mod.__source;
+  let offset = 0;
+  let changed = false;
+
+  for (const match of matches) {
     const matchStart = match.index;
 
-    // Skip if this match is inside a preserved element
+    // Skip if inside a preserved element
     if (protectedRanges.some(([start, end]) => matchStart >= start && matchStart < end)) continue;
 
-    // Replace the entire match with \n\n (one blank line)
-    const replacement = '\n\n';
-    const start = matchStart;
-    const end = matchStart + match[0].length;
-    mod.__source = mod.__source.slice(0, start) + replacement + mod.__source.slice(end);
-    mod.__trackDelta(removeDelta(start + replacement.length, end));
+    const shiftedStart = matchStart + offset;
+    const shiftedEnd = shiftedStart + match[0].length;
+    newSource = newSource.slice(0, shiftedStart) + '\n\n' + newSource.slice(shiftedEnd);
+    offset += 2 - match[0].length;
+    changed = true;
   }
 
-  mod.__cachedInnerHTML = new WeakMap();
-  mod.__cachedOuterHTML = new WeakMap();
+  if (changed) {
+    // Re-parse to sync AST — collapse can affect text nodes, comments,
+    // and content that spans multiple AST node types.
+    resetHtmlMod(mod, newSource);
+  }
 }
 
 /**
@@ -499,12 +491,43 @@ function trimFormattingWhitespace(mod: HtmlMod): void {
   const leadingMatch = /^[\t\n\f\r ]+/.exec(mod.__source);
   if (leadingMatch) {
     const { length } = leadingMatch[0];
+    // Check if the first child is a whitespace text node — update or remove it
+    const firstChild = mod.__dom.children[0];
+    if (firstChild && isText(firstChild)) {
+      const textNode = firstChild as SourceText;
+      const newData = textNode.data.slice(length);
+      if (newData) {
+        textNode.data = newData;
+        textNode.startIndex = 0;
+        textNode.endIndex = newData.length - 1;
+      } else {
+        // Remove the text node entirely
+        mod.__dom.children.shift();
+        const newFirst = mod.__dom.children[0];
+        if (newFirst) (newFirst as { prev?: unknown }).prev = null;
+      }
+    }
     mod.__source = mod.__source.slice(length);
     mod.__trackDelta(removeDelta(0, length));
   }
 
   const trailingMatch = /[\t\n\f\r ]+$/.exec(mod.__source);
   if (trailingMatch) {
+    // Check if the last child is a whitespace text node — update or remove it
+    const lastChild = mod.__dom.children.at(-1);
+    if (lastChild && isText(lastChild)) {
+      const textNode = lastChild as SourceText;
+      const trimLength = trailingMatch[0].length;
+      const newData = textNode.data.slice(0, -trimLength);
+      if (newData) {
+        textNode.data = newData;
+        textNode.endIndex = textNode.startIndex + newData.length - 1;
+      } else {
+        mod.__dom.children.pop();
+        const newLast = mod.__dom.children.at(-1);
+        if (newLast) (newLast as { next?: unknown }).next = null;
+      }
+    }
     mod.__source = mod.__source.slice(0, -trailingMatch[0].length);
   }
 }
@@ -534,6 +557,7 @@ function insertWhitespaceBefore(
   } else {
     mod.__prependLeft(startPos, whitespace);
     mod.__trackDelta(prependLeftDelta(startPos, whitespace));
+    spliceTextNodeBefore(node as SourceChildNode, whitespace, startPos);
   }
 }
 
@@ -553,7 +577,70 @@ function insertWhitespaceAfter(
   } else {
     mod.__appendRight(endPos, whitespace);
     mod.__trackDelta(appendRightDelta(endPos, whitespace));
+    spliceTextNodeAfter(node as SourceChildNode, whitespace, endPos);
   }
+}
+
+/**
+ * Create a text node and splice it into the parent's children array
+ * before the reference node.  This keeps the AST consistent with the
+ * source string after raw insertions on comment/directive nodes.
+ */
+function spliceTextNodeBefore(referenceNode: SourceChildNode, data: string, position: number): void {
+  const parent = (referenceNode as { parent?: { children?: SourceChildNode[] } }).parent;
+  if (!parent?.children) return;
+
+  const textNode = createTextNode(data, position);
+  (textNode as { parent?: unknown }).parent = parent;
+
+  const index = parent.children.indexOf(referenceNode);
+  if (index === -1) return;
+
+  // Link siblings
+  const previous = parent.children[index - 1] ?? null;
+  (textNode as { prev?: unknown }).prev = previous;
+  (textNode as { next?: unknown }).next = referenceNode;
+  if (previous) (previous as { next?: unknown }).next = textNode;
+  (referenceNode as { prev?: unknown }).prev = textNode;
+
+  parent.children.splice(index, 0, textNode as SourceChildNode);
+}
+
+function spliceTextNodeAfter(referenceNode: SourceChildNode, data: string, position: number): void {
+  const parent = (referenceNode as { parent?: { children?: SourceChildNode[] } }).parent;
+  if (!parent?.children) return;
+
+  const textNode = createTextNode(data, position);
+  (textNode as { parent?: unknown }).parent = parent;
+
+  const index = parent.children.indexOf(referenceNode);
+  if (index === -1) return;
+
+  // Link siblings
+  const next = parent.children[index + 1] ?? null;
+  (textNode as { prev?: unknown }).prev = referenceNode;
+  (textNode as { next?: unknown }).next = next;
+  (referenceNode as { next?: unknown }).next = textNode;
+  if (next) (next as { prev?: unknown }).prev = textNode;
+
+  parent.children.splice(index + 1, 0, textNode as SourceChildNode);
+}
+
+function createTextNode(data: string, position: number): SourceText {
+  // Construct a minimal SourceText-compatible object.
+  // domhandler Text nodes are duck-typed — the AST walker and
+  // nodeToString only check type, data, startIndex, endIndex.
+  return {
+    type: 'text',
+    data,
+    startIndex: position,
+    endIndex: position + data.length - 1,
+    // These will be set by spliceTextNode*
+    parent: null,
+    prev: null,
+    next: null,
+    nodeType: 3,
+  } as unknown as SourceText;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -2,10 +2,30 @@ import { HtmlMod, HtmlModElement, HtmlModText } from '@ciolabs/html-mod';
 import type { SourceElement, SourceText, SourceChildNode } from '@ciolabs/htmlparser2-source';
 import { isComment, isDirective, isTag, isText } from '@ciolabs/htmlparser2-source';
 
-/**
- * Inline HTML elements — we never add newlines around these.
- * Includes legacy/deprecated tags still common in email HTML.
- */
+// Position delta helpers — matches the shape expected by HtmlMod.__trackDelta.
+// Inlined to avoid sub-path import issues with moduleResolution: node.
+const removeDelta = (start: number, end: number) => ({
+  operationType: 'remove' as const,
+  mutationStart: start,
+  mutationEnd: end,
+  delta: -(end - start),
+});
+const prependLeftDelta = (index: number, content: string) => ({
+  operationType: 'prependLeft' as const,
+  mutationStart: index,
+  mutationEnd: index,
+  delta: content.length,
+});
+const appendRightDelta = (index: number, content: string) => ({
+  operationType: 'appendRight' as const,
+  mutationStart: index,
+  mutationEnd: index,
+  delta: content.length,
+});
+
+// TODO: Replace with `isInlineElement` from `@ciolabs/html-element-display`
+// once that package is merged. It covers the full WHATWG spec including
+// table-related display types which this hardcoded set does not.
 const INLINE_ELEMENTS = new Set([
   'a',
   'abbr',
@@ -51,9 +71,6 @@ const INLINE_ELEMENTS = new Set([
   'wbr',
 ]);
 
-/**
- * Elements whose content whitespace must never be touched.
- */
 const PRESERVE_CONTENT = new Set(['pre', 'code', 'textarea']);
 
 export interface PrettifyOptions {
@@ -65,8 +82,6 @@ export interface PrettifyOptions {
 
   /**
    * Maximum line length before attribute wrapping kicks in (default 0 = off).
-   * When an opening tag exceeds this length, attributes are wrapped onto
-   * new lines (one per line, indented to align or by one indent level).
    */
   maxLineLength?: number;
 
@@ -84,23 +99,13 @@ export interface PrettifyOptions {
    * (default true).
    */
   collapseBlankLines?: boolean;
-
-  /**
-   * Whether to increase indentation depth for content that appears
-   * after a conditional comment.  When `false`, content after
-   * `<!--[if mso]>...<![endif]-->` stays at the same indent level
-   * as the comment itself (default true).
-   */
-  indentAfterConditionalComments?: boolean;
 }
 
-/** Resolved options with defaults applied */
 interface ResolvedOptions {
   indent: string;
   maxLineLength: number;
   wrapAttributes: 'auto' | 'force' | 'force-aligned' | false;
   collapseBlankLines: boolean;
-  indentAfterConditionalComments: boolean;
 }
 
 function resolveOptions(options?: PrettifyOptions): ResolvedOptions {
@@ -111,7 +116,6 @@ function resolveOptions(options?: PrettifyOptions): ResolvedOptions {
     maxLineLength: options?.maxLineLength ?? 0,
     wrapAttributes: options?.wrapAttributes ?? 'auto',
     collapseBlankLines: options?.collapseBlankLines ?? true,
-    indentAfterConditionalComments: options?.indentAfterConditionalComments ?? true,
   };
 }
 
@@ -129,21 +133,17 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
   const mod = typeof input === 'string' ? new HtmlMod(input) : input;
   const resolved = resolveOptions(options);
 
-  // Format the document tree.
   // Depth -1 so that top-level elements sit at indent 0.
   formatChildren(mod, mod.__dom.children as Iterable<SourceElement | SourceText>, -1, resolved);
 
-  // Wrap long opening tags by breaking attributes onto new lines.
   if (resolved.wrapAttributes !== false && resolved.maxLineLength > 0) {
     wrapLongAttributes(mod, resolved);
   }
 
-  // Collapse consecutive blank lines.
   if (resolved.collapseBlankLines) {
     collapseConsecutiveBlankLines(mod);
   }
 
-  // Trim only HTML formatting whitespace at document boundaries.
   trimFormattingWhitespace(mod);
 
   return mod;
@@ -153,11 +153,6 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
 // Core formatting
 // ---------------------------------------------------------------------------
 
-/**
- * Walk `children` and ensure correct indentation between block-level
- * siblings.  Operates entirely through HtmlMod text-node mutations so
- * the AST stays in sync.
- */
 function formatChildren(
   mod: HtmlMod,
   children: Iterable<SourceElement | SourceText>,
@@ -167,7 +162,6 @@ function formatChildren(
   const childArray = [...children];
   const { indent } = options;
 
-  // Determine if this list contains any block-level content.
   const hasBlock = childArray.some(
     child =>
       (isTag(child) && !isInline(child as SourceElement)) ||
@@ -177,9 +171,7 @@ function formatChildren(
 
   if (!hasBlock) return;
 
-  // Build a set of child indices protected by single-line bubble conditionals.
   const protectedIndices = buildProtectedBubbleIndices(childArray);
-
   const childIndent = indent.repeat(Math.max(0, depth + 1));
   const parentIndent = indent.repeat(Math.max(0, depth));
 
@@ -189,7 +181,7 @@ function formatChildren(
     const isFirst = index === 0;
     const isLast = index === childArray.length - 1;
 
-    // --- Whitespace text nodes between siblings --------------------------
+    // --- Whitespace text nodes -------------------------------------------
     if (isText(child)) {
       const textNode = child as SourceText;
       const nextSibling = childArray[index + 1];
@@ -202,24 +194,16 @@ function formatChildren(
       continue;
     }
 
-    // --- Ensure leading whitespace before any non-text node ---------------
+    // --- Leading whitespace for non-text nodes ---------------------------
     if (isFirst) {
-      if (isTag(child)) {
-        insertBeforeIfNeeded(mod, child as SourceElement, `\n${childIndent}`);
-      } else if (isComment(child) || isDirective(child)) {
-        insertBeforeComment(mod, child, `\n${childIndent}`);
-      }
+      insertWhitespaceBefore(mod, child, `\n${childIndent}`);
     } else if (
       previous &&
       !isText(previous) &&
       !(hasInlineBlockStyle(previous) && hasInlineBlockStyle(child)) &&
       !protectedIndices.has(index)
     ) {
-      if (isTag(previous)) {
-        insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
-      } else if (isComment(previous) || isDirective(previous)) {
-        insertAfterComment(mod, previous, `\n${childIndent}`);
-      }
+      insertWhitespaceAfter(mod, previous, `\n${childIndent}`);
     }
 
     // --- Element nodes ---------------------------------------------------
@@ -227,36 +211,28 @@ function formatChildren(
       const element = child as SourceElement;
 
       if (isInline(element)) {
-        if (isLast) {
-          insertAfterIfNeeded(mod, element, `\n${parentIndent}`);
-        }
+        if (isLast) insertWhitespaceAfter(mod, element, `\n${parentIndent}`);
         continue;
       }
 
-      // Recurse into children (unless content is preserved)
       if (!isPreserved(element) && element.children.length > 0) {
         formatChildren(mod, element.children as Iterable<SourceElement | SourceText>, depth + 1, options);
       }
 
-      if (isLast) {
-        insertAfterIfNeeded(mod, element, `\n${parentIndent}`);
-      }
+      if (isLast) insertWhitespaceAfter(mod, element, `\n${parentIndent}`);
     }
 
-    // --- Comment nodes ----------------------------------------------------
+    // --- Comment nodes ---------------------------------------------------
     if (isComment(child)) {
-      if (isLast) {
-        insertAfterComment(mod, child, `\n${parentIndent}`);
-      }
-
+      if (isLast) insertWhitespaceAfter(mod, child, `\n${parentIndent}`);
       if (isMultiLineConditional(child)) {
         formatInsideConditionalComment(mod, child, depth + 1, options);
       }
     }
 
-    // --- Directive nodes (<!DOCTYPE html>, etc.) --------------------------
+    // --- Directive nodes (<!DOCTYPE html>, etc.) -------------------------
     if (isDirective(child) && isLast) {
-      insertAfterComment(mod, child, `\n${parentIndent}`);
+      insertWhitespaceAfter(mod, child, `\n${parentIndent}`);
     }
   }
 }
@@ -287,6 +263,8 @@ function formatInsideConditionalComment(
 
   const commentIndent = indent.repeat(Math.max(0, depth));
 
+  // When formatChildren was a no-op (e.g. closing tags parsed as text),
+  // re-indent every line.  Otherwise use the formatter's output.
   const innerFormatted =
     innerMod.__source === trimmedInnerHtml
       ? trimmedInnerHtml
@@ -296,25 +274,29 @@ function formatInsideConditionalComment(
       : innerMod.__source.replace(/^\n/, '').replace(/[\t\n\f\r ]+$/, '');
 
   const formatted = `\n${innerFormatted}\n${commentIndent}`;
-
   const newData = `${openMatch[0]}${formatted}${closeMatch[0]}`;
   if (newData === data) return;
 
-  const dataStart = startIndex + 4;
-  const dataEnd = endIndex - 2;
+  const dataStart = startIndex + 4; // after '<!--'
+  const dataEnd = endIndex - 2; // before '-->'
   const oldLength = dataEnd - dataStart;
-  const { length: newLength } = newData;
 
   mod.__source = mod.__source.slice(0, dataStart) + newData + mod.__source.slice(dataStart + oldLength);
 
-  const delta = newLength - oldLength;
-
-  if (delta !== 0) {
-    shiftPositionsAfter(mod.__dom.children, endIndex + 1, delta);
-  }
-
+  // Update comment node before the full tree walk so it doesn't get
+  // double-shifted.  Then shift everything after the original end.
+  const netDelta = newData.length - oldLength;
   commentNode.data = newData;
-  commentNode.endIndex += delta;
+  commentNode.endIndex += netDelta;
+
+  if (netDelta !== 0) {
+    mod.__trackDelta({
+      operationType: 'appendRight',
+      mutationStart: endIndex + 1,
+      mutationEnd: endIndex + 1,
+      delta: netDelta,
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -323,55 +305,38 @@ function formatInsideConditionalComment(
 
 /**
  * Wrap attributes on opening tags that exceed `maxLineLength`.
- * Breaks before each attribute onto a new line — saves one character
- * compared to breaking after, and keeps lines short without adding
- * a space character:
+ * Uses the "break before attribute" style:
  * ```
  * <p
  *   style="margin:1em 0">
  * ```
  *
- * Uses regex on the source string after structural formatting.
+ * Rewrites the inside of opening tags in a single pass.  Each tag's
+ * attribute positions shift independently, making incremental AST
+ * updates impractical — a re-parse is the correct approach here.
  */
 function wrapLongAttributes(mod: HtmlMod, options: ResolvedOptions): void {
   const { maxLineLength, wrapAttributes, indent } = options;
-
-  // Match opening tags with attributes: <tagname attr1="val" attr2="val" ...>
-  // Captures: (1) tag start `<tagname`, (2) attributes block, (3) closing `>` or `/>`
   const openTagRegex = /(<[a-z][\da-z-]*)((?:\s+[^\s/=>]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]*))?)+)(\s*\/?>)/gi;
 
   let newSource = mod.__source;
   let offset = 0;
 
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   for (const match of mod.__source.matchAll(openTagRegex)) {
     const fullMatch = match[0];
-    const tagStart = match[1]; // e.g. "<p"
-    const attributesPart = match[2]; // e.g. ' class="x" style="y"'
-    const closing = match[3]; // e.g. ">" or " />"
+    const tagStart = match[1];
+    const attributesPart = match[2];
+    const closing = match[3];
     const matchIndex = match.index;
 
-    // Calculate the line this tag starts on to get indentation
     const lineStart = mod.__source.lastIndexOf('\n', matchIndex) + 1;
     const leadingWhitespace = mod.__source.slice(lineStart, matchIndex);
-    const tagLineLength = leadingWhitespace.length + fullMatch.length;
 
-    // For 'auto' mode, skip tags that fit on one line
-    if (wrapAttributes === 'auto' && tagLineLength <= maxLineLength) {
-      continue;
-    }
+    if (wrapAttributes === 'auto' && leadingWhitespace.length + fullMatch.length <= maxLineLength) continue;
 
-    // Parse individual attributes
-    const attributes: string[] = [];
-    const attributeRegex = /\s+([^\s/=>]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]*))?)/g;
-    let attributeMatch;
-    while ((attributeMatch = attributeRegex.exec(attributesPart)) !== null) {
-      attributes.push(attributeMatch[1]);
-    }
-
+    const attributes = parseAttributes(attributesPart);
     if (attributes.length === 0) continue;
 
-    // Build wrapped replacement
     let replacement: string;
     if (wrapAttributes === 'force-aligned') {
       const alignIndent = ' '.repeat(leadingWhitespace.length + tagStart.length + 1);
@@ -389,96 +354,113 @@ function wrapLongAttributes(mod: HtmlMod, options: ResolvedOptions): void {
       replacement += closing;
     }
 
-    // Apply replacement at shifted position
     const shiftedIndex = matchIndex + offset;
     newSource = newSource.slice(0, shiftedIndex) + replacement + newSource.slice(shiftedIndex + fullMatch.length);
     offset += replacement.length - fullMatch.length;
   }
 
   if (newSource !== mod.__source) {
-    const fresh = new HtmlMod(newSource, mod.__options);
-    mod.__source = fresh.__source;
-    mod.__dom = fresh.__dom;
-    mod.__astUpdater = fresh.__astUpdater;
-    mod.__cachedInnerHTML = new WeakMap();
-    mod.__cachedOuterHTML = new WeakMap();
+    resetHtmlMod(mod, newSource);
   }
 }
 
+function parseAttributes(attributesPart: string): string[] {
+  const attributes: string[] = [];
+  const regex = /\s+([^\s/=>]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]*))?)/g;
+  let match;
+  while ((match = regex.exec(attributesPart)) !== null) {
+    attributes.push(match[1]);
+  }
+  return attributes;
+}
+
 // ---------------------------------------------------------------------------
-// Whitespace collapsing
+// Post-processing
 // ---------------------------------------------------------------------------
 
 /**
- * Collapse runs of 2+ consecutive blank lines into a single blank line.
+ * Collapse runs of 3+ consecutive newlines into 2 (one blank line).
+ * Processes from end to start so positions stay valid.
  */
 function collapseConsecutiveBlankLines(mod: HtmlMod): void {
-  const collapsed = mod.__source.replaceAll(/\n{3,}/g, '\n\n');
-  if (collapsed !== mod.__source) {
-    const fresh = new HtmlMod(collapsed, mod.__options);
-    mod.__source = fresh.__source;
-    mod.__dom = fresh.__dom;
-    mod.__astUpdater = fresh.__astUpdater;
-    mod.__cachedInnerHTML = new WeakMap();
-    mod.__cachedOuterHTML = new WeakMap();
+  const matches = [...mod.__source.matchAll(/\n{3,}/g)];
+  if (matches.length === 0) return;
+
+  for (let index = matches.length - 1; index >= 0; index--) {
+    const match = matches[index];
+    const start = match.index + 2;
+    const end = match.index + match[0].length;
+    mod.__source = mod.__source.slice(0, start) + mod.__source.slice(end);
+    mod.__trackDelta(removeDelta(start, end));
+  }
+
+  mod.__cachedInnerHTML = new WeakMap();
+  mod.__cachedOuterHTML = new WeakMap();
+}
+
+function trimFormattingWhitespace(mod: HtmlMod): void {
+  const leadingMatch = /^[\t\n\f\r ]+/.exec(mod.__source);
+  if (leadingMatch) {
+    const { length } = leadingMatch[0];
+    mod.__source = mod.__source.slice(length);
+    mod.__trackDelta(removeDelta(0, length));
+  }
+
+  const trailingMatch = /[\t\n\f\r ]+$/.exec(mod.__source);
+  if (trailingMatch) {
+    mod.__source = mod.__source.slice(0, -trailingMatch[0].length);
   }
 }
 
 // ---------------------------------------------------------------------------
-// Text node helpers
+// Whitespace insertion
 // ---------------------------------------------------------------------------
 
 function setTextContent(mod: HtmlMod, textNode: SourceText, content: string): void {
   if (textNode.data === content) return;
-  const textWrapper = new HtmlModText(textNode, mod);
-  textWrapper.innerHTML = content;
+  new HtmlModText(textNode, mod).innerHTML = content;
 }
 
-function insertBeforeIfNeeded(mod: HtmlMod, element: SourceElement, whitespace: string): void {
-  const charBefore = mod.__source[element.source.openTag.startIndex - 1];
-  if (charBefore === '>' || charBefore === undefined) {
-    const wrapper = new HtmlModElement(element, mod);
-    wrapper.before(whitespace);
-  }
-}
-
-function insertAfterIfNeeded(mod: HtmlMod, element: SourceElement, whitespace: string): void {
-  const endPos = element.source.closeTag?.endIndex ?? element.endIndex + 1;
-  const charAfter = mod.__source[endPos];
-  if (charAfter === '<' || charAfter === undefined) {
-    const wrapper = new HtmlModElement(element, mod);
-    wrapper.after(whitespace);
-  }
-}
-
-function insertBeforeComment(
+function insertWhitespaceBefore(
   mod: HtmlMod,
-  commentNode: { startIndex: number; endIndex: number },
+  node: SourceElement | SourceText | SourceChildNode,
   whitespace: string
 ): void {
-  const startPos = commentNode.startIndex;
+  const startPos = isTag(node)
+    ? (node as SourceElement).source.openTag.startIndex
+    : (node as { startIndex: number }).startIndex;
   const charBefore = mod.__source[startPos - 1];
-  if (charBefore === '>' || charBefore === undefined) {
+  if (charBefore !== '>' && charBefore !== undefined) return;
+
+  if (isTag(node)) {
+    new HtmlModElement(node as SourceElement, mod).before(whitespace);
+  } else {
     mod.__prependLeft(startPos, whitespace);
-    shiftPositionsAfter(mod.__dom.children, startPos, whitespace.length);
+    mod.__trackDelta(prependLeftDelta(startPos, whitespace));
   }
 }
 
-function insertAfterComment(
+function insertWhitespaceAfter(
   mod: HtmlMod,
-  commentNode: { startIndex: number; endIndex: number },
+  node: SourceElement | SourceText | SourceChildNode,
   whitespace: string
 ): void {
-  const endPos = commentNode.endIndex + 1;
+  const endPos = isTag(node)
+    ? ((node as SourceElement).source.closeTag?.endIndex ?? (node as SourceElement).endIndex + 1)
+    : (node as { endIndex: number }).endIndex + 1;
   const charAfter = mod.__source[endPos];
-  if (charAfter === '<' || charAfter === undefined) {
+  if (charAfter !== '<' && charAfter !== undefined) return;
+
+  if (isTag(node)) {
+    new HtmlModElement(node as SourceElement, mod).after(whitespace);
+  } else {
     mod.__appendRight(endPos, whitespace);
-    shiftPositionsAfter(mod.__dom.children, endPos, whitespace.length);
+    mod.__trackDelta(appendRightDelta(endPos, whitespace));
   }
 }
 
 // ---------------------------------------------------------------------------
-// Classification helpers
+// Classification
 // ---------------------------------------------------------------------------
 
 function isInline(element: SourceElement): boolean {
@@ -498,12 +480,10 @@ function hasInlineBlockStyle(node: SourceChildNode): boolean {
   return /display\s*:\s*inline-block/i.test(style);
 }
 
-/** Bubble open comment data ends with `><!`: e.g. `[if !mso]><!` */
 function isBubbleOpenData(data: string): boolean {
   return /\[if\s/i.test(data) && data.endsWith('><!');
 }
 
-/** Bubble close comment data: e.g. `<![endif]` */
 function isBubbleCloseData(data: string): boolean {
   return /\[endif]/i.test(data) && data.startsWith('<!');
 }
@@ -512,22 +492,8 @@ function isWhitespaceOnly(string_: string): boolean {
   return /^[\t\n\f\r ]*$/.test(string_);
 }
 
-/** Strip leading and trailing HTML formatting whitespace, preserving NBSP. */
 function trimFormatting(string_: string): string {
   return string_.replace(/^[\t\n\f\r ]+/, '').replace(/[\t\n\f\r ]+$/, '');
-}
-
-function trimFormattingWhitespace(mod: HtmlMod): void {
-  const leadingMatch = /^[\t\n\f\r ]+/.exec(mod.__source);
-  if (leadingMatch) {
-    mod.__source = mod.__source.slice(leadingMatch[0].length);
-    shiftPositionsAfter(mod.__dom.children, 0, -leadingMatch[0].length);
-  }
-
-  const trailingMatch = /[\t\n\f\r ]+$/.exec(mod.__source);
-  if (trailingMatch) {
-    mod.__source = mod.__source.slice(0, -trailingMatch[0].length);
-  }
 }
 
 function isMultiLineConditional(node: { data?: string }): boolean {
@@ -543,6 +509,15 @@ function isMultiLineConditional(node: { data?: string }): boolean {
   return inner.includes('\n');
 }
 
+// ---------------------------------------------------------------------------
+// Bubble conditional protection
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a set of child indices protected by single-line bubble conditional
+ * pairs.  Identifies open/close structurally in the sibling list so a
+ * single-line bubble doesn't accidentally protect a later multi-line one.
+ */
 function buildProtectedBubbleIndices(childArray: Array<SourceElement | SourceText | SourceChildNode>): Set<number> {
   const protectedSet = new Set<number>();
 
@@ -570,9 +545,7 @@ function buildProtectedBubbleIndices(childArray: Array<SourceElement | SourceTex
           }
           break;
         }
-        if (isBubbleOpenData(siblingData)) {
-          break;
-        }
+        if (isBubbleOpenData(siblingData)) break;
       }
     }
   }
@@ -581,67 +554,14 @@ function buildProtectedBubbleIndices(childArray: Array<SourceElement | SourceTex
 }
 
 // ---------------------------------------------------------------------------
-// Position shifting
+// HtmlMod reset (for operations that must re-parse)
 // ---------------------------------------------------------------------------
 
-interface AstNode {
-  startIndex: number | null;
-  endIndex: number | null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  children?: Iterable<any>;
-  data?: string;
-  source?: {
-    openTag: { startIndex: number; endIndex: number };
-    closeTag?: { startIndex: number; endIndex: number } | null;
-    attributes?: Array<{
-      name: { startIndex: number; endIndex: number };
-      value?: { startIndex: number; endIndex: number } | null;
-      source: { startIndex: number; endIndex: number };
-    }>;
-  };
-}
-
-function shiftPositionsAfter(nodes: Iterable<AstNode>, afterPos: number, delta: number): void {
-  for (const node of nodes) {
-    if (node.startIndex == null || node.endIndex == null) {
-      if (node.children) {
-        shiftPositionsAfter(node.children, afterPos, delta);
-      }
-      continue;
-    }
-
-    if (node.startIndex >= afterPos) {
-      node.startIndex += delta;
-      node.endIndex += delta;
-
-      if (node.source?.openTag) {
-        node.source.openTag.startIndex += delta;
-        node.source.openTag.endIndex += delta;
-        if (node.source.closeTag) {
-          node.source.closeTag.startIndex += delta;
-          node.source.closeTag.endIndex += delta;
-        }
-        for (const attribute of node.source.attributes ?? []) {
-          attribute.name.startIndex += delta;
-          attribute.name.endIndex += delta;
-          if (attribute.value) {
-            attribute.value.startIndex += delta;
-            attribute.value.endIndex += delta;
-          }
-          attribute.source.startIndex += delta;
-          attribute.source.endIndex += delta;
-        }
-      }
-    } else if (node.endIndex >= afterPos) {
-      node.endIndex += delta;
-      if (node.source?.closeTag && node.source.closeTag.startIndex >= afterPos) {
-        node.source.closeTag.startIndex += delta;
-        node.source.closeTag.endIndex += delta;
-      }
-    }
-
-    if (node.children) {
-      shiftPositionsAfter(node.children, afterPos, delta);
-    }
-  }
+function resetHtmlMod(mod: HtmlMod, newSource: string): void {
+  const fresh = new HtmlMod(newSource, mod.__options);
+  mod.__source = fresh.__source;
+  mod.__dom = fresh.__dom;
+  mod.__astUpdater = fresh.__astUpdater;
+  mod.__cachedInnerHTML = new WeakMap();
+  mod.__cachedOuterHTML = new WeakMap();
 }

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -148,19 +148,17 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
     wrapLongAttributes(mod, resolved);
   }
 
-  // Re-sync AST after formatting + wrapping.  formatChildren uses a mix of
-  // AST-aware ops (HtmlModElement.before/after) and raw string ops (for
-  // comments/directives) that track deltas but don't create text nodes.
-  // wrapLongAttributes rewrites opening tags.  Re-parsing here ensures
-  // positions are valid for collapse/trim, and that any HtmlModElement
-  // handles captured before prettify() are detached cleanly.
-  resetHtmlMod(mod, mod.__source);
-
   if (resolved.collapseBlankLines) {
     collapseConsecutiveBlankLines(mod);
   }
 
   trimFormattingWhitespace(mod);
+
+  // Final re-parse to sync the AST with the source.  Formatting uses a mix
+  // of AST-aware ops and raw string mutations.  Collapse and trim further
+  // mutate __source.  This ensures the returned HtmlMod has a consistent
+  // AST for downstream querySelector/textContent/innerHTML.
+  resetHtmlMod(mod, mod.__source);
 
   return mod;
 }
@@ -461,42 +459,18 @@ function collapseConsecutiveBlankLines(mod: HtmlMod): void {
 
 /**
  * Collect source ranges of content inside preserved elements (pre, code,
- * textarea).  Walks the AST and also scans the raw source with regex to
- * catch preserved elements inside conditional comments (which are comment
- * text to the parser, not in the AST).
+ * textarea).  Scans the raw source string directly — works regardless of
+ * whether the AST is synced, and catches preserved elements inside
+ * conditional comments (which are comment text to the parser).
  */
 function buildPreservedContentRanges(mod: HtmlMod): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
-
-  // Walk the AST for top-level preserved elements
-  const walk = (nodes: Iterable<SourceElement | SourceText | SourceChildNode>) => {
-    for (const node of nodes) {
-      if (isTag(node)) {
-        const element = node as SourceElement;
-        if (isPreserved(element)) {
-          const contentStart = element.source.openTag.endIndex + 1;
-          const contentEnd = element.source.closeTag?.startIndex ?? element.endIndex;
-          ranges.push([contentStart, contentEnd]);
-        } else if (element.children.length > 0) {
-          walk(element.children as Iterable<SourceElement | SourceText | SourceChildNode>);
-        }
-      }
-    }
-  };
-  walk(mod.__dom.children as Iterable<SourceElement | SourceText | SourceChildNode>);
-
-  // Also scan raw source for preserved elements inside comments
-  // (conditional comment content is not in the AST)
   const preservedTagRegex = /<(pre|code|textarea)\b[^>]*>([\S\s]*?)<\/\1>/gi;
   for (const match of mod.__source.matchAll(preservedTagRegex)) {
     const openTagEnd = match.index + match[0].indexOf('>') + 1;
     const closeTagStart = match.index + match[0].lastIndexOf('</');
-    // Only add if not already covered by an AST range
-    if (!ranges.some(([start, end]) => openTagEnd >= start && closeTagStart <= end)) {
-      ranges.push([openTagEnd, closeTagStart]);
-    }
+    ranges.push([openTagEnd, closeTagStart]);
   }
-
   return ranges;
 }
 

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -96,11 +96,14 @@ function formatChildren(
 ): void {
   const childArray = [...children];
 
-  // Determine if this list contains any block-level elements.
-  // If it's all inline / text / comments we leave it alone.
+  // Determine if this list contains any block-level content.
+  // If it's all inline / text we leave it alone.
   // Preserved elements (pre, code, textarea) count as block — we format
   // whitespace *around* them, just not inside them.
-  const hasBlock = childArray.some(child => isTag(child) && !isInline(child as SourceElement));
+  // Multi-line conditional comments also count — they need internal formatting.
+  const hasBlock = childArray.some(
+    child => (isTag(child) && !isInline(child as SourceElement)) || (isComment(child) && isMultiLineConditional(child))
+  );
 
   if (!hasBlock) return;
 
@@ -212,29 +215,38 @@ function formatInsideConditionalComment(
   const closeMatch = /<!\[endif]$/.exec(data);
   if (!openMatch || !closeMatch) return;
 
-  const innerHtml = data.slice(openMatch[0].length, data.length - closeMatch[0].length);
-  if (!innerHtml.trim()) return;
+  const rawInnerHtml = data.slice(openMatch[0].length, data.length - closeMatch[0].length);
+  const trimmedInnerHtml = rawInnerHtml.trim();
+  if (!trimmedInnerHtml) return;
 
-  // Format the inner HTML in a scoped HtmlMod
-  const innerMod = new HtmlMod(innerHtml);
-  const innerSingleLineRanges = buildSingleLineConditionalRanges(innerHtml);
+  // Format the inner HTML in a scoped HtmlMod.
+  // Trim first so the formatter sees clean HTML without leading/trailing
+  // whitespace that would produce bad indentation at the top level.
+  // Pass depth - 1 because formatChildren adds 1 for children — the
+  // inner content should be indented at `depth` level (matching where
+  // the comment sits in the outer document).
+  const innerMod = new HtmlMod(trimmedInnerHtml);
+  const innerSingleLineRanges = buildSingleLineConditionalRanges(trimmedInnerHtml);
   formatChildren(
     innerMod,
     innerMod.__dom.children as Iterable<SourceElement | SourceText>,
-    depth,
+    depth - 1,
     indent,
     innerSingleLineRanges
   );
 
-  let formatted = innerMod.__source;
+  // Align the close tag (<![endif]) with the open tag (<!--[if).
+  // The caller passes `depth + 1`, so `depth` here equals the comment's
+  // own indentation level in the outer document.
+  const commentIndent = indent.repeat(Math.max(0, depth));
+  let innerFormatted = innerMod.__source.trimEnd();
 
-  // Ensure leading newline and trailing newline + indent for alignment
-  const parentIndent = indent.repeat(Math.max(0, depth - 1));
-  formatted = formatted.startsWith('\n') ? formatted : `\n${formatted}`;
+  // Ensure a leading newline so content starts on the line after <!--[if]>
+  if (!innerFormatted.startsWith('\n')) {
+    innerFormatted = `\n${commentIndent}${innerFormatted}`;
+  }
 
-  formatted = formatted.endsWith('\n')
-    ? formatted.replace(/\n\s*$/, `\n${parentIndent}`)
-    : `${formatted}\n${parentIndent}`;
+  const formatted = `${innerFormatted}\n${commentIndent}`;
 
   const newData = `${openMatch[0]}${formatted}${closeMatch[0]}`;
   if (newData === data) return;

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -214,6 +214,7 @@ function formatChildren(
     } else if (
       previous &&
       !isText(previous) &&
+      !areBothInline(previous, child) &&
       !(hasInlineBlockStyle(previous) && hasInlineBlockStyle(child)) &&
       !protectedIndices.has(index)
     ) {
@@ -548,6 +549,13 @@ function isInline(element: SourceElement): boolean {
 
 function isPreserved(element: SourceElement): boolean {
   return PRESERVE_CONTENT.has(element.tagName.toLowerCase());
+}
+
+function areBothInline(
+  nodeA: SourceElement | SourceText | SourceChildNode,
+  nodeB: SourceElement | SourceText | SourceChildNode
+): boolean {
+  return isTag(nodeA) && isTag(nodeB) && isInline(nodeA as SourceElement) && isInline(nodeB as SourceElement);
 }
 
 function hasInlineBlockStyle(node: SourceChildNode): boolean {

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -424,7 +424,9 @@ function wrapLongAttributes(mod: HtmlMod, options: ResolvedOptions): void {
   }
 
   if (newSource !== mod.__source) {
-    mod.__source = newSource;
+    // Wrapping rewrites opening tags across the document — each tag's
+    // attribute positions shift independently.  Re-parse to sync the AST.
+    resetHtmlMod(mod, newSource);
   }
 }
 

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -136,7 +136,12 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
   // Depth -1 so that top-level elements sit at indent 0.
   formatChildren(mod, mod.__dom.children as Iterable<SourceElement | SourceText>, -1, resolved);
 
-  if (resolved.wrapAttributes !== false && resolved.maxLineLength > 0) {
+  // Wrap attributes when: force/force-aligned (always), or auto with maxLineLength > 0
+  if (
+    resolved.wrapAttributes === 'force' ||
+    resolved.wrapAttributes === 'force-aligned' ||
+    (resolved.wrapAttributes === 'auto' && resolved.maxLineLength > 0)
+  ) {
     wrapLongAttributes(mod, resolved);
   }
 
@@ -291,12 +296,11 @@ function formatInsideConditionalComment(
 
   mod.__source = mod.__source.slice(0, dataStart) + newData + mod.__source.slice(dataStart + oldLength);
 
-  // Update comment node before the full tree walk so it doesn't get
-  // double-shifted.  Then shift everything after the original end.
   const netDelta = newData.length - oldLength;
-  commentNode.data = newData;
-  commentNode.endIndex += netDelta;
 
+  // Shift sibling positions FIRST, then update the comment node.
+  // __trackDelta walks the full tree — if we update commentNode.endIndex
+  // before the walk, the walker can double-shift it.
   if (netDelta !== 0) {
     mod.__trackDelta({
       operationType: 'appendRight',
@@ -305,6 +309,9 @@ function formatInsideConditionalComment(
       delta: netDelta,
     });
   }
+
+  commentNode.data = newData;
+  commentNode.endIndex += netDelta;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -109,6 +109,9 @@ function formatChildren(
 
   for (let index = 0; index < childArray.length; index++) {
     const child = childArray[index];
+    const previous = childArray[index - 1];
+    const isFirst = index === 0;
+    const isLast = index === childArray.length - 1;
 
     // --- Whitespace text nodes between siblings --------------------------
     // In a block context, normalize whitespace-only text nodes to the
@@ -116,28 +119,37 @@ function formatChildren(
     if (isText(child)) {
       const textNode = child as SourceText;
       if (isWhitespaceOnly(textNode.data) && !isInsideSingleLineConditional(textNode, singleLineRanges)) {
-        // Determine what indent to use: if this is the last child
-        // (whitespace before parent close tag), use parentIndent.
-        const isLast = index === childArray.length - 1;
         setTextContent(mod, textNode, `\n${isLast ? parentIndent : childIndent}`);
       }
       continue;
+    }
+
+    // --- Ensure leading whitespace before any non-text node ---------------
+    // If there's no text node before this child (either it's the first
+    // child, or the previous sibling is also a tag/comment), insert one.
+    if (isFirst) {
+      if (isTag(child)) {
+        insertBeforeIfNeeded(mod, child as SourceElement, `\n${childIndent}`);
+      } else if (isComment(child)) {
+        insertBeforeComment(mod, child, `\n${childIndent}`);
+      }
+    } else if (previous && !isText(previous)) {
+      // Two non-text nodes adjacent — insert whitespace between them.
+      // Use the previous node's end position to insert after it.
+      if (isTag(previous)) {
+        insertAfterIfNeeded(mod, previous as SourceElement, `\n${childIndent}`);
+      } else if (isComment(previous)) {
+        insertAfterComment(mod, previous, `\n${childIndent}`);
+      }
     }
 
     // --- Element nodes ---------------------------------------------------
     if (isTag(child)) {
       const element = child as SourceElement;
 
-      // If first child and no leading text node, insert whitespace
-      const previous = childArray[index - 1];
-      if (!previous) {
-        insertBeforeIfNeeded(mod, element, `\n${childIndent}`);
-      }
-
-      // Skip recursion for inline elements — only adjust surrounding whitespace
+      // Skip recursion for inline elements
       if (isInline(element)) {
-        // If last child, ensure trailing whitespace before parent close
-        if (index === childArray.length - 1) {
+        if (isLast) {
           insertAfterIfNeeded(mod, element, `\n${parentIndent}`);
         }
         continue;
@@ -154,29 +166,16 @@ function formatChildren(
         );
       }
 
-      // Fix trailing whitespace (before next sibling or before parent close tag)
-      const next = childArray[index + 1];
-      if (!next) {
-        // Last child — ensure whitespace before parent close tag
+      // Ensure trailing whitespace if last child
+      if (isLast) {
         insertAfterIfNeeded(mod, element, `\n${parentIndent}`);
       }
     }
 
     // --- Comment nodes ----------------------------------------------------
     if (isComment(child)) {
-      // Fix leading whitespace before this comment
-      const previous = childArray[index - 1];
-      if (previous && isText(previous)) {
-        const textNode = previous as SourceText;
-        if (isWhitespaceOnly(textNode.data) && !isInsideSingleLineConditional(textNode, singleLineRanges)) {
-          setTextContent(mod, textNode, `\n${childIndent}`);
-        }
-      }
-
-      // Fix trailing whitespace
-      const next = childArray[index + 1];
-      if (!next) {
-        // Comment is last child — add whitespace before parent close
+      // Ensure trailing whitespace if last child
+      if (isLast) {
         insertAfterComment(mod, child, `\n${parentIndent}`);
       }
 
@@ -287,6 +286,19 @@ function insertAfterIfNeeded(mod: HtmlMod, element: SourceElement, whitespace: s
   if (charAfter === '<' || charAfter === undefined) {
     const wrapper = new HtmlModElement(element, mod);
     wrapper.after(whitespace);
+  }
+}
+
+function insertBeforeComment(
+  mod: HtmlMod,
+  commentNode: { startIndex: number; endIndex: number },
+  whitespace: string
+): void {
+  const startPos = commentNode.startIndex;
+  const charBefore = mod.__source[startPos - 1];
+  if (charBefore === '>' || charBefore === undefined) {
+    mod.__prependLeft(startPos, whitespace);
+    shiftPositionsAfter(mod.__dom.children, startPos, whitespace.length);
   }
 }
 

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -146,6 +146,13 @@ export default function prettify(input: HtmlMod | string, options?: PrettifyOpti
 
   trimFormattingWhitespace(mod);
 
+  // Re-sync the AST to match the final source.  Formatting uses a mix of
+  // AST-aware operations (HtmlModElement.before/after, HtmlModText.innerHTML)
+  // and raw string operations (for comments/directives).  The raw operations
+  // track position deltas but don't create/remove AST text nodes.  A final
+  // re-parse ensures the AST is fully consistent for downstream consumers.
+  resetHtmlMod(mod, mod.__source);
+
   return mod;
 }
 
@@ -311,67 +318,96 @@ function formatInsideConditionalComment(
  *   style="margin:1em 0">
  * ```
  *
- * Rewrites the inside of opening tags in a single pass.  Each tag's
- * attribute positions shift independently, making incremental AST
- * updates impractical — a re-parse is the correct approach here.
+ * Walks the AST to find elements (safe from comments/inline text),
+ * then rewrites their opening tags.  A re-parse at the end of prettify()
+ * syncs the AST.
  */
 function wrapLongAttributes(mod: HtmlMod, options: ResolvedOptions): void {
   const { maxLineLength, wrapAttributes, indent } = options;
-  const openTagRegex = /(<[a-z][\da-z-]*)((?:\s+[^\s/=>]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]*))?)+)(\s*\/?>)/gi;
 
+  // Collect elements that need wrapping, with their source positions.
+  // Walk the AST so we only touch real element opening tags.
+  const targets: Array<{ element: SourceElement; openTagSource: string; startIndex: number }> = [];
+
+  const walk = (nodes: Iterable<SourceElement | SourceText | SourceChildNode>) => {
+    for (const node of nodes) {
+      if (!isTag(node)) continue;
+      const element = node as SourceElement;
+
+      // Check if this element's opening tag needs wrapping
+      if (element.source.attributes.length > 0) {
+        const openStart = element.source.openTag.startIndex;
+        const openEnd = element.source.openTag.endIndex + 1;
+        const openTagSource = mod.__source.slice(openStart, openEnd);
+
+        const lineStart = mod.__source.lastIndexOf('\n', openStart) + 1;
+        const leadingLength = openStart - lineStart;
+        const tagLineLength = leadingLength + openTagSource.length;
+
+        if (wrapAttributes !== 'auto' || tagLineLength > maxLineLength) {
+          targets.push({ element, openTagSource, startIndex: openStart });
+        }
+      }
+
+      // Always walk children
+      if (element.children.length > 0) {
+        walk(element.children as Iterable<SourceElement | SourceText | SourceChildNode>);
+      }
+    }
+  };
+  walk(mod.__dom.children as Iterable<SourceElement | SourceText | SourceChildNode>);
+
+  if (targets.length === 0) return;
+
+  // Process from end to start so earlier positions stay valid
   let newSource = mod.__source;
-  let offset = 0;
+  for (let index = targets.length - 1; index >= 0; index--) {
+    const { element, openTagSource, startIndex } = targets[index];
+    const openEnd = element.source.openTag.endIndex + 1;
 
-  for (const match of mod.__source.matchAll(openTagRegex)) {
-    const fullMatch = match[0];
-    const tagStart = match[1];
-    const attributesPart = match[2];
-    const closing = match[3];
-    const matchIndex = match.index;
+    // Parse tag name and attributes from the source
+    const tagNameMatch = /^<([^\s/=>]+)/.exec(openTagSource);
+    if (!tagNameMatch) continue;
+    const tagName = tagNameMatch[0]; // e.g. "<table"
 
-    const lineStart = mod.__source.lastIndexOf('\n', matchIndex) + 1;
-    const leadingWhitespace = mod.__source.slice(lineStart, matchIndex);
-
-    if (wrapAttributes === 'auto' && leadingWhitespace.length + fullMatch.length <= maxLineLength) continue;
-
-    const attributes = parseAttributes(attributesPart);
+    // Extract individual attribute strings from source attributes
+    const attributes: string[] = [];
+    for (const attribute of element.source.attributes) {
+      attributes.push(attribute.source.data);
+    }
     if (attributes.length === 0) continue;
+
+    // Get the closing part (> or />)
+    const lastAttributeEnd = element.source.attributes.at(-1)!.source.endIndex + 1;
+    const closing = openTagSource.slice(lastAttributeEnd - startIndex);
+
+    // Build replacement
+    const lineStart = newSource.lastIndexOf('\n', startIndex) + 1;
+    const leadingWhitespace = newSource.slice(lineStart, startIndex);
 
     let replacement: string;
     if (wrapAttributes === 'force-aligned') {
-      const alignIndent = ' '.repeat(leadingWhitespace.length + tagStart.length + 1);
-      replacement = `${tagStart} ${attributes[0]}`;
+      const alignIndent = ' '.repeat(leadingWhitespace.length + tagName.length + 1);
+      replacement = `${tagName} ${attributes[0]}`;
       for (let attributeIndex = 1; attributeIndex < attributes.length; attributeIndex++) {
         replacement += `\n${alignIndent}${attributes[attributeIndex]}`;
       }
       replacement += closing;
     } else {
       const attributeIndent = leadingWhitespace + indent;
-      replacement = tagStart;
+      replacement = tagName;
       for (const attribute of attributes) {
         replacement += `\n${attributeIndent}${attribute}`;
       }
       replacement += closing;
     }
 
-    const shiftedIndex = matchIndex + offset;
-    newSource = newSource.slice(0, shiftedIndex) + replacement + newSource.slice(shiftedIndex + fullMatch.length);
-    offset += replacement.length - fullMatch.length;
+    newSource = newSource.slice(0, startIndex) + replacement + newSource.slice(openEnd);
   }
 
   if (newSource !== mod.__source) {
-    resetHtmlMod(mod, newSource);
+    mod.__source = newSource;
   }
-}
-
-function parseAttributes(attributesPart: string): string[] {
-  const attributes: string[] = [];
-  const regex = /\s+([^\s/=>]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]*))?)/g;
-  let match;
-  while ((match = regex.exec(attributesPart)) !== null) {
-    attributes.push(match[1]);
-  }
-  return attributes;
 }
 
 // ---------------------------------------------------------------------------
@@ -380,22 +416,55 @@ function parseAttributes(attributesPart: string): string[] {
 
 /**
  * Collapse runs of 3+ consecutive newlines into 2 (one blank line).
- * Processes from end to start so positions stay valid.
+ * Skips content inside preserved elements (pre, code, textarea).
  */
 function collapseConsecutiveBlankLines(mod: HtmlMod): void {
+  // Build a set of character ranges to protect
+  const protectedRanges = buildPreservedContentRanges(mod);
+
   const matches = [...mod.__source.matchAll(/\n{3,}/g)];
   if (matches.length === 0) return;
 
+  // Process from end to start so positions stay valid
   for (let index = matches.length - 1; index >= 0; index--) {
     const match = matches[index];
-    const start = match.index + 2;
-    const end = match.index + match[0].length;
+    const matchStart = match.index;
+
+    // Skip if this match is inside a preserved element
+    if (protectedRanges.some(([start, end]) => matchStart >= start && matchStart < end)) continue;
+
+    const start = matchStart + 2;
+    const end = matchStart + match[0].length;
     mod.__source = mod.__source.slice(0, start) + mod.__source.slice(end);
     mod.__trackDelta(removeDelta(start, end));
   }
 
   mod.__cachedInnerHTML = new WeakMap();
   mod.__cachedOuterHTML = new WeakMap();
+}
+
+/**
+ * Collect source ranges of content inside preserved elements (pre, code,
+ * textarea).  Used to protect these ranges from post-processing operations.
+ */
+function buildPreservedContentRanges(mod: HtmlMod): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const walk = (nodes: Iterable<SourceElement | SourceText | SourceChildNode>) => {
+    for (const node of nodes) {
+      if (isTag(node)) {
+        const element = node as SourceElement;
+        if (isPreserved(element)) {
+          const contentStart = element.source.openTag.endIndex + 1;
+          const contentEnd = element.source.closeTag?.startIndex ?? element.endIndex;
+          ranges.push([contentStart, contentEnd]);
+        } else if (element.children.length > 0) {
+          walk(element.children as Iterable<SourceElement | SourceText | SourceChildNode>);
+        }
+      }
+    }
+  };
+  walk(mod.__dom.children as Iterable<SourceElement | SourceText | SourceChildNode>);
+  return ranges;
 }
 
 function trimFormattingWhitespace(mod: HtmlMod): void {

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -201,8 +201,9 @@ function formatChildren(
       const nextSibling = childArray[index + 1];
       const betweenInlineBlocks =
         previous && nextSibling && hasInlineBlockStyle(previous) && hasInlineBlockStyle(nextSibling);
+      const betweenInlines = previous && nextSibling && areBothInline(previous, nextSibling);
 
-      if (isWhitespaceOnly(textNode.data) && !betweenInlineBlocks && !protectedIndices.has(index)) {
+      if (isWhitespaceOnly(textNode.data) && !betweenInlineBlocks && !betweenInlines && !protectedIndices.has(index)) {
         setTextContent(mod, textNode, `\n${isLast ? parentIndent : childIndent}`);
       }
       continue;
@@ -263,7 +264,7 @@ function formatInsideConditionalComment(
   options: ResolvedOptions
 ): void {
   const { data, startIndex, endIndex } = commentNode;
-  const { indent } = options;
+  const { indent, wrapAttributes, maxLineLength } = options;
 
   const openMatch = /^\[if\s[^]*?]>/i.exec(data);
   const closeMatch = /<!\[endif]$/i.exec(data);
@@ -275,6 +276,17 @@ function formatInsideConditionalComment(
 
   const innerMod = new HtmlMod(trimmedInnerHtml);
   formatChildren(innerMod, innerMod.__dom.children as Iterable<SourceElement | SourceText>, depth - 1, options);
+
+  // Also wrap attributes inside the conditional comment content
+  if (
+    wrapAttributes === 'force' ||
+    wrapAttributes === 'force-aligned' ||
+    (wrapAttributes === 'auto' && maxLineLength > 0)
+  ) {
+    // Re-parse innerMod so the AST is valid for the wrap walk
+    resetHtmlMod(innerMod, innerMod.__source);
+    wrapLongAttributes(innerMod, options);
+  }
 
   const commentIndent = indent.repeat(Math.max(0, depth));
 
@@ -437,7 +449,10 @@ function collapseConsecutiveBlankLines(mod: HtmlMod): void {
   // Build a set of character ranges to protect
   const protectedRanges = buildPreservedContentRanges(mod);
 
-  const matches = [...mod.__source.matchAll(/\n{3,}/g)];
+  // Match 2+ consecutive blank lines — a blank line is \n followed by
+  // optional whitespace then another \n.  This catches both `\n\n\n`
+  // and `\n  \n  \n` (indented blank lines).
+  const matches = [...mod.__source.matchAll(/\n([\t ]*\n){2,}/g)];
   if (matches.length === 0) return;
 
   // Process from end to start so positions stay valid
@@ -448,10 +463,12 @@ function collapseConsecutiveBlankLines(mod: HtmlMod): void {
     // Skip if this match is inside a preserved element
     if (protectedRanges.some(([start, end]) => matchStart >= start && matchStart < end)) continue;
 
-    const start = matchStart + 2;
+    // Replace the entire match with \n\n (one blank line)
+    const replacement = '\n\n';
+    const start = matchStart;
     const end = matchStart + match[0].length;
-    mod.__source = mod.__source.slice(0, start) + mod.__source.slice(end);
-    mod.__trackDelta(removeDelta(start, end));
+    mod.__source = mod.__source.slice(0, start) + replacement + mod.__source.slice(end);
+    mod.__trackDelta(removeDelta(start + replacement.length, end));
   }
 
   mod.__cachedInnerHTML = new WeakMap();

--- a/packages/html-email-prettify/src/index.ts
+++ b/packages/html-email-prettify/src/index.ts
@@ -144,12 +144,18 @@ function formatChildren(
     // --- Whitespace text nodes between siblings --------------------------
     // In a block context, normalize whitespace-only text nodes to the
     // correct indentation regardless of what follows (block or inline).
-    // Skip text nodes that sit between bubble comment pairs — those are
-    // inside a single-line conditional and must not be touched.
+    // Skip when:
+    // - The text sits between bubble comment pairs (single-line conditional)
+    // - The text separates two display:inline-block elements (column gap)
     if (isText(child)) {
       const textNode = child as SourceText;
+      const nextSibling = childArray[index + 1];
+      const betweenInlineBlocks =
+        previous && nextSibling && hasInlineBlockStyle(previous) && hasInlineBlockStyle(nextSibling);
+
       if (
         isWhitespaceOnly(textNode.data) &&
+        !betweenInlineBlocks &&
         !(hasBubbleSibling && isTextBetweenBubbleComments(index, childArray, bubbleCommentData))
       ) {
         setTextContent(mod, textNode, `\n${isLast ? parentIndent : childIndent}`);
@@ -414,44 +420,64 @@ function isMultiLineConditional(node: { data?: string }): boolean {
 
 /**
  * Check whether a text node at `index` in `childArray` sits between
- * two comments that form a single-line bubble conditional.  This is a
- * position-independent check — it walks siblings by array index, so it
- * survives source mutations that shift absolute offsets.
+ * an open and close comment that form a single-line bubble conditional.
+ *
+ * Tracks matched pairs so two separate conditionals in the same list
+ * don't falsely protect the gap between them.  Open comments have data
+ * containing `[if` and close comments have data containing `[endif]`.
  */
 function isTextBetweenBubbleComments(
   index: number,
   childArray: Array<SourceElement | SourceText | SourceChildNode>,
   bubbleData: Set<string>
 ): boolean {
-  // Scan backwards for a bubble open comment
+  // Scan backwards for the nearest bubble OPEN comment (data has "[if")
   let foundOpen = false;
   for (let before = index - 1; before >= 0; before--) {
     const node = childArray[before];
-    if (isComment(node) && bubbleData.has((node as { data?: string }).data ?? '')) {
+    if (!isComment(node)) continue;
+    const data = (node as { data?: string }).data ?? '';
+    if (!bubbleData.has(data)) continue;
+
+    if (/\[if\s/i.test(data)) {
+      // Found an open — but only if there's no close between it and us
+      // (which would mean a complete conditional before our text node)
       foundOpen = true;
       break;
+    }
+    if (/\[endif]/i.test(data)) {
+      // Hit a close comment before finding an open — we're outside
+      return false;
     }
   }
   if (!foundOpen) return false;
 
-  // Scan forwards for a bubble close comment
+  // Scan forwards for the matching bubble CLOSE comment (data has "[endif]")
   for (let after = index + 1; after < childArray.length; after++) {
     const node = childArray[after];
-    if (isComment(node) && bubbleData.has((node as { data?: string }).data ?? '')) {
+    if (!isComment(node)) continue;
+    const data = (node as { data?: string }).data ?? '';
+    if (!bubbleData.has(data)) continue;
+
+    if (/\[endif]/i.test(data)) {
       return true;
+    }
+    if (/\[if\s/i.test(data)) {
+      // Hit a new open before finding the close — we're outside
+      return false;
     }
   }
   return false;
 }
 
 /**
- * Check whether either adjacent node is a comment that belongs to a
- * single-line bubble/revealed conditional.  This protects patterns like
- * `<!--[if !mso]><!-->...<![endif]-->` where inserting whitespace next
- * to the comment would break inline-block layouts.
+ * Check whether two adjacent non-text nodes are both inside the same
+ * single-line bubble conditional.  Returns true only when:
+ * - nodeA is a bubble open comment and nodeB is content after it, OR
+ * - nodeA is content and nodeB is a bubble close comment
  *
- * Unlike position-range checks, this uses comment data strings which
- * don't shift during formatting.
+ * Does NOT protect the gap between a close and a subsequent open —
+ * that's between two separate conditionals and should be formatted.
  */
 function isBubbleCommentBoundary(
   nodeA: SourceElement | SourceText | SourceChildNode,
@@ -459,12 +485,19 @@ function isBubbleCommentBoundary(
   bubbleData: Set<string>
 ): boolean {
   if (bubbleData.size === 0) return false;
-  for (const node of [nodeA, nodeB]) {
-    if (isComment(node)) {
-      const data = (node as { data?: string }).data ?? '';
-      if (bubbleData.has(data)) return true;
-    }
+
+  // nodeA is a bubble open → nodeB is inside the conditional
+  if (isComment(nodeA)) {
+    const data = (nodeA as { data?: string }).data ?? '';
+    if (bubbleData.has(data) && /\[if\s/i.test(data)) return true;
   }
+
+  // nodeB is a bubble close → nodeA is inside the conditional
+  if (isComment(nodeB)) {
+    const data = (nodeB as { data?: string }).data ?? '';
+    if (bubbleData.has(data) && /\[endif]/i.test(data)) return true;
+  }
+
   return false;
 }
 

--- a/packages/html-email-prettify/tsconfig.json
+++ b/packages/html-email-prettify/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/html-email-prettify/tsup.config.ts
+++ b/packages/html-email-prettify/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+import baseConfig from '../../tsup.config';
+
+export default defineConfig({
+  ...baseConfig,
+  entry: ['src/index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,6 @@ importers:
 
   packages/html-email-prettify:
     dependencies:
-      '@ciolabs/html-find-conditional-comments':
-        specifier: workspace:*
-        version: link:../html-find-conditional-comments
       '@ciolabs/html-mod':
         specifier: workspace:*
         version: link:../html-mod

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,24 @@ importers:
         specifier: ^7.0.16
         version: 7.1.3
 
+  packages/html-email-prettify:
+    dependencies:
+      '@ciolabs/html-find-conditional-comments':
+        specifier: workspace:*
+        version: link:../html-find-conditional-comments
+      '@ciolabs/html-mod':
+        specifier: workspace:*
+        version: link:../html-mod
+      '@ciolabs/html-process-conditional-comments':
+        specifier: workspace:*
+        version: link:../html-process-conditional-comments
+      '@types/js-beautify':
+        specifier: ^1.13.3
+        version: 1.14.3
+      js-beautify:
+        specifier: ~1.13.4
+        version: 1.13.13
+
   packages/html-find-conditional-comments: {}
 
   packages/html-mod:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,15 +174,9 @@ importers:
       '@ciolabs/html-mod':
         specifier: workspace:*
         version: link:../html-mod
-      '@ciolabs/html-process-conditional-comments':
+      '@ciolabs/htmlparser2-source':
         specifier: workspace:*
-        version: link:../html-process-conditional-comments
-      '@types/js-beautify':
-        specifier: ^1.13.3
-        version: 1.14.3
-      js-beautify:
-        specifier: ~1.13.4
-        version: 1.13.13
+        version: link:../htmlparser2-source
 
   packages/html-find-conditional-comments: {}
 


### PR DESCRIPTION
## TL;DR

New `@ciolabs/html-email-prettify` package — formats email HTML using AST-based whitespace manipulation on top of html-mod. No re-parse, no js-beautify, the HtmlMod instance stays live.

## Problem

After a bunch of html-mod edits (innerHTML, before/after, remove, etc.), the output HTML ends up with messy indentation. The existing `html-email-formatter` uses js-beautify which rewrites the entire string and requires a full re-parse to get valid AST positions back.

## Solution

Walk the html-mod AST and adjust whitespace text nodes directly using html-mod's position-tracked operations. The formatter:

- Accepts `HtmlMod | string` — mutates in place when given HtmlMod, returns new HtmlMod for strings
- Normalizes indentation of block elements via `HtmlModText.innerHTML` edits
- Leaves inline elements alone (no added gaps between `<span>`, `<a>`, `<img>`, etc.)
- Preserves single-line conditional comments verbatim (Mark's button pattern, ghost tables)
- Formats inside multi-line conditional comments in a scoped HtmlMod (small isolated re-parse)
- Consistent indentation for closing-tag-only conditional comments (`</td></tr></table>`)
- Protects downlevel-revealed bubble comments (`<!--[if !mso]><!-->...<!--<![endif]-->`)
- Skips whitespace insertion between adjacent `display:inline-block` elements
- Never touches `<pre>`, `<code>`, `<textarea>` content

## Dependencies

- `@ciolabs/html-mod` — AST walking + string operations
- `@ciolabs/html-find-conditional-comments` — detecting conditional comments
- `@ciolabs/htmlparser2-source` — type guards

No external formatting libraries.

## Test plan

81 tests covering:
- basic formatting + indentation
- pre/code/textarea preservation
- single-line conditional comments (Mark's button, ghost tables, entities)
- multi-line conditional comment formatting + alignment
- closing-tag-only conditional comment indentation
- downlevel-revealed/bubble conditional whitespace protection
- inline element adjacency
- display:inline-block column preservation
- HtmlMod integration (mutation, querying, chaining edits)
- real-world email patterns
- idempotency
- edit-then-format workflows
- options (indentSize, indentChar)
- AST integrity after formatting (querySelector, further edits)
- edge cases (nested comments, malformed HTML, empty input)