### PR TITLE
fix(html-mod): prevent self-closing tag position-drift corruption

### DIFF
--- a/.changeset/html-mod-self-closing-drift.md
+++ b/.changeset/html-mod-self-closing-drift.md
@@ -1,0 +1,11 @@
+---
+'@ciolabs/html-mod': patch
+---
+
+Fix position-drift data corruption on self-closing tags. Mutating a
+self-closing element (`<img src="y"/>`, `<br>`, `<x-card ... />`) via
+`prepend`/`append`/`innerHTML`/`textContent`/`expandSelfClosing` could leave
+the tracked AST positions out of sync with the source string, so a subsequent
+edit wrote bytes to the wrong location (e.g. `<b> id="x">hi</b>` or
+`<brx</br>>`). All of these paths now keep `openTag.endIndex`, the synthesized
+close tag, and `element.endIndex` consistent with the parser's conventions.

--- a/.changeset/html-mod-self-closing-drift.md
+++ b/.changeset/html-mod-self-closing-drift.md
@@ -2,10 +2,24 @@
 '@ciolabs/html-mod': patch
 ---
 
-Fix position-drift data corruption on self-closing tags. Mutating a
-self-closing element (`<img src="y"/>`, `<br>`, `<x-card ... />`) via
-`prepend`/`append`/`innerHTML`/`textContent`/`expandSelfClosing` could leave
-the tracked AST positions out of sync with the source string, so a subsequent
-edit wrote bytes to the wrong location (e.g. `<b> id="x">hi</b>` or
-`<brx</br>>`). All of these paths now keep `openTag.endIndex`, the synthesized
-close tag, and `element.endIndex` consistent with the parser's conventions.
+Fix several data-corruption / data-loss bugs where the tracked AST fell out of
+sync with the source string:
+
+- **Self-closing tags.** Mutating a self-closing element (`<img src="y"/>`,
+  `<br>`, `<x-card ... />`) via `prepend`/`append`/`innerHTML`/`textContent`/
+  `expandSelfClosing` left positions out of sync, so a later edit wrote to the
+  wrong place (e.g. `<b> id="x">hi</b>`, `<brx</br>>`). These paths now keep
+  `openTag.endIndex`, the synthesized close tag, and `element.endIndex`
+  consistent with the parser's conventions.
+- **Implicitly-closed / unclosed elements.** For an element with no close tag
+  (a `<td>`/`<li>`/`<p>` closed implicitly by a following sibling, common in
+  email HTML) the parser's `endIndex` overshoots into the next sibling.
+  `innerHTML`/`append`/`textContent` ate the next element and
+  `outerHTML`/`after`/`remove`/`replaceWith` spanned into it — e.g.
+  `remove()` on the first of `<td>1<td>2` deleted _both_ cells. Content and
+  outer boundaries are now derived from the element's own last descendant.
+- **`trim`/`trimStart`/`trimEnd`/`trimLines`.** Trimmed boundary whitespace was
+  removed from the string but left as stale/phantom text nodes in the AST (and
+  trimming both ends mis-applied the trailing delta). The AST is now reconciled.
+- **`HtmlModText` at index 0.** A one-character text node at the start of the
+  document (`endIndex === 0`) silently dropped `textContent`/`innerHTML` writes.

--- a/packages/html-mod/src/ast-manipulator.ts
+++ b/packages/html-mod/src/ast-manipulator.ts
@@ -384,5 +384,11 @@ export function convertToRegularTag(
       data: `</${element.tagName}>`,
       name: element.tagName,
     };
+
+    // The element now ends at the close tag. Keep element.endIndex (the
+    // inclusive index of the final `>`, i.e. closeTagEnd - 1) in sync, or
+    // later position updates whose mutation starts past the stale endIndex
+    // will short-circuit and leave the close tag pointing at the wrong place.
+    element.endIndex = closeTagEnd - 1;
   }
 }

--- a/packages/html-mod/src/element-utils.ts
+++ b/packages/html-mod/src/element-utils.ts
@@ -1,7 +1,7 @@
 /**
  * Element utility functions for common operations
  */
-import type { SourceElement } from '@ciolabs/htmlparser2-source';
+import type { SourceElement, SourceChildNode } from '@ciolabs/htmlparser2-source';
 
 /**
  * Get the start position of an element's content (after opening tag)
@@ -11,10 +11,47 @@ export function getContentStart(element: SourceElement): number {
 }
 
 /**
- * Get the end position of an element's content (before closing tag)
+ * Get the end position of an element's content (exclusive — one past the last
+ * content character, i.e. where a closing tag would begin).
+ *
+ * For a properly closed element this is the close tag's start. For an element
+ * with no close tag (an implicitly-closed <td>/<li>/<p>, or an unclosed tag)
+ * the parser's element.endIndex can overshoot into a *following sibling*, so we
+ * derive the boundary from the element's own last descendant instead. That
+ * keeps innerHTML/append/textContent from reading or overwriting into the next
+ * element and destroying it.
  */
 export function getContentEnd(element: SourceElement): number {
-  return element.source.closeTag?.startIndex ?? element.endIndex;
+  if (element.source.closeTag) {
+    return element.source.closeTag.startIndex;
+  }
+  return lastDescendantEnd(element);
+}
+
+/**
+ * Exclusive end position of an element's own content, computed from its last
+ * child (recursively), ignoring the parser's possibly-overshooting endIndex.
+ */
+function lastDescendantEnd(element: SourceElement): number {
+  const children = element.children as SourceChildNode[] | undefined;
+  if (!children || children.length === 0) {
+    // No content: the boundary is right after the open tag.
+    return element.source.openTag.endIndex + 1;
+  }
+
+  const last = children.at(-1);
+
+  if (last.type === 'tag') {
+    const lastElement = last as SourceElement;
+    if (lastElement.source?.closeTag) {
+      return lastElement.source.closeTag.endIndex; // exclusive
+    }
+    // The last child is itself unclosed — recurse so we don't trust its endIndex.
+    return lastDescendantEnd(lastElement);
+  }
+
+  // Text/comment/CDATA: endIndex is the inclusive last character.
+  return (last.endIndex ?? element.source.openTag.endIndex) + 1;
 }
 
 /**
@@ -25,6 +62,18 @@ export function getContentRange(element: SourceElement): { start: number; end: n
     start: getContentStart(element),
     end: getContentEnd(element),
   };
+}
+
+/**
+ * Get the exclusive end position of an element's *outer* HTML (one past the
+ * final `>` of its close tag, or — for an element with no close tag — one past
+ * its last content character). Like getContentEnd, this avoids the parser's
+ * endIndex which can overshoot into a following sibling for implicitly-closed
+ * elements, which would otherwise make remove()/replaceWith()/after()/outerHTML
+ * swallow the next element.
+ */
+export function getOuterEnd(element: SourceElement): number {
+  return element.source.closeTag?.endIndex ?? getContentEnd(element);
 }
 
 /**

--- a/packages/html-mod/src/element-utils.ts
+++ b/packages/html-mod/src/element-utils.ts
@@ -40,6 +40,9 @@ function lastDescendantEnd(element: SourceElement): number {
   }
 
   const last = children.at(-1);
+  if (!last) {
+    return element.source.openTag.endIndex + 1;
+  }
 
   if (last.type === 'tag') {
     const lastElement = last as SourceElement;

--- a/packages/html-mod/src/expand-self-closing.test.ts
+++ b/packages/html-mod/src/expand-self-closing.test.ts
@@ -91,4 +91,67 @@ describe('expandSelfClosing', () => {
     element.expandSelfClosing();
     expect(element.isSelfClosing).toBe(false);
   });
+
+  describe('AST stays consistent after expansion (no follow-up corruption)', () => {
+    test('outerHTML/toString are complete after expansion', () => {
+      const h = new HtmlMod('<x-p>a <x-icon name="star"/> b</x-p>');
+      const icon = h.querySelectorAll('x-icon')[0];
+      icon.expandSelfClosing();
+      expect(icon.outerHTML).toBe('<x-icon name="star"></x-icon>');
+      expect(icon.toString()).toBe('<x-icon name="star"></x-icon>');
+    });
+
+    test('setAttribute after expansion does not corrupt the document', () => {
+      const h = new HtmlMod('<x-p>a <x-icon name="star"/> b</x-p>');
+      const icon = h.querySelectorAll('x-icon')[0];
+      icon.expandSelfClosing();
+      icon.dataset.source = 'ZZZ';
+      expect(h.toString()).toBe('<x-p>a <x-icon name="star" data-source="ZZZ"></x-icon> b</x-p>');
+    });
+
+    test('innerHTML is empty after expansion', () => {
+      const h = new HtmlMod('<x-icon name="star"/>');
+      const icon = h.querySelector('x-icon')!;
+      icon.expandSelfClosing();
+      expect(icon.innerHTML).toBe('');
+    });
+
+    test('after() inserts at the right position after expansion', () => {
+      const h = new HtmlMod('<wrap><x-icon/> tail</wrap>');
+      h.querySelector('x-icon')!.expandSelfClosing();
+      h.querySelector('x-icon')!.after('<b></b>');
+      expect(h.toString()).toBe('<wrap><x-icon></x-icon><b></b> tail</wrap>');
+    });
+
+    test('before() inserts at the right position after expansion', () => {
+      const h = new HtmlMod('<wrap><x-icon/> tail</wrap>');
+      h.querySelector('x-icon')!.expandSelfClosing();
+      h.querySelector('x-icon')!.before('<b></b>');
+      expect(h.toString()).toBe('<wrap><b></b><x-icon></x-icon> tail</wrap>');
+    });
+
+    test('append() inserts inside the element after expansion', () => {
+      const h = new HtmlMod('<wrap><x-icon/></wrap>');
+      h.querySelector('x-icon')!.expandSelfClosing();
+      h.querySelector('x-icon')!.append('<b>hi</b>');
+      expect(h.toString()).toBe('<wrap><x-icon><b>hi</b></x-icon></wrap>');
+    });
+
+    test('mixed-case tag round-trips after expansion + setAttribute', () => {
+      const h = new HtmlMod('<wrap><X-Image src="a"/></wrap>');
+      h.querySelector('x-image')!.expandSelfClosing();
+      // Open tag preserves source casing; close tag uses the parser tag name.
+      expect(h.toString()).toBe('<wrap><X-Image src="a"></x-image></wrap>');
+      h.querySelector('x-image')!.dataset.source = 'ZZZ';
+      expect(h.toString()).toBe('<wrap><X-Image src="a" data-source="ZZZ"></x-image></wrap>');
+    });
+
+    test('spaced form round-trips after expansion + setAttribute', () => {
+      const h = new HtmlMod('<wrap><x-spacer /></wrap>');
+      h.querySelector('x-spacer')!.expandSelfClosing();
+      expect(h.toString()).toBe('<wrap><x-spacer></x-spacer></wrap>');
+      h.querySelector('x-spacer')!.dataset.source = 'ZZZ';
+      expect(h.toString()).toBe('<wrap><x-spacer data-source="ZZZ"></x-spacer></wrap>');
+    });
+  });
 });

--- a/packages/html-mod/src/html-mod-text.test.ts
+++ b/packages/html-mod/src/html-mod-text.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression tests for HtmlModText setters.
+ *
+ * A text node positioned at the very start of the document has endIndex === 0.
+ * The old `if (!this.__text.endIndex) return;` guard treated that valid index
+ * as falsy and silently dropped the write — data loss.
+ */
+import type { SourceText } from '@ciolabs/htmlparser2-source';
+import { describe, expect, test } from 'vitest';
+
+import { HtmlMod, HtmlModText } from './index';
+
+function rootText(h: HtmlMod): HtmlModText {
+  const node = (h as unknown as { __dom: { children: any[] } }).__dom.children.find((c: any) => c.type === 'text');
+  return new HtmlModText(node as SourceText, h);
+}
+
+describe('HtmlModText setters', () => {
+  test('textContent on a single-char text node at index 0 is not dropped', () => {
+    const h = new HtmlMod('a<div>x</div>');
+    rootText(h).textContent = 'CHANGED';
+    expect(h.toString()).toBe('CHANGED<div>x</div>');
+  });
+
+  test('innerHTML on a single-char text node at index 0 is not dropped', () => {
+    const h = new HtmlMod('a<div>x</div>');
+    rootText(h).innerHTML = '<b>hi</b>';
+    expect(h.toString()).toBe('<b>hi</b><div>x</div>');
+  });
+
+  test('setting text at index 0 keeps following siblings in sync', () => {
+    const h = new HtmlMod('a<b id="x">y</b>');
+    rootText(h).textContent = 'LONGER';
+    h.querySelector('b')!.dataset.z = '1';
+    expect(h.toString()).toBe('LONGER<b id="x" data-z="1">y</b>');
+  });
+
+  test('multi-char leading text node still works (no regression)', () => {
+    const h = new HtmlMod('hello<div>x</div>');
+    rootText(h).textContent = 'hi';
+    h.querySelector('div')!.setAttribute('k', 'v');
+    expect(h.toString()).toBe('hi<div k="v">x</div>');
+  });
+});

--- a/packages/html-mod/src/implicit-close-content.test.ts
+++ b/packages/html-mod/src/implicit-close-content.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for content-boundary corruption on elements with no close
+ * tag that are followed by siblings — i.e. implicitly-closed elements such as
+ * <td>, <li>, <tr>, <option>, <p>. The parser gives such an element an
+ * endIndex that overshoots into the following sibling, so innerHTML/append/
+ * textContent (which used endIndex as the content end) read or overwrite into
+ * the next element, destroying it.
+ *
+ * This is common in real email HTML (tables full of implicitly-closed cells).
+ */
+import { describe, expect, test } from 'vitest';
+
+import { HtmlMod } from './index';
+
+describe('implicit-close content boundaries', () => {
+  test('innerHTML on first implicit <td> does not eat the next cell', () => {
+    const h = new HtmlMod('<table><tr><td>1<td>2</tr></table>');
+    h.querySelectorAll('td')[0].innerHTML = 'X';
+    expect(h.toString()).toBe('<table><tr><td>X<td>2</tr></table>');
+  });
+
+  test('innerHTML getter on first implicit <td> returns only its own content', () => {
+    const h = new HtmlMod('<table><tr><td>1<td>2</tr></table>');
+    expect(h.querySelectorAll('td')[0].innerHTML).toBe('1');
+  });
+
+  test('append on first implicit <td> inserts into that cell', () => {
+    const h = new HtmlMod('<table><tr><td>1<td>2</tr></table>');
+    h.querySelectorAll('td')[0].append('<b>!</b>');
+    expect(h.toString()).toBe('<table><tr><td>1<b>!</b><td>2</tr></table>');
+  });
+
+  test('textContent on first implicit <td> does not eat the next cell', () => {
+    const h = new HtmlMod('<table><tr><td>1<td>2</tr></table>');
+    h.querySelectorAll('td')[0].textContent = 'Z';
+    expect(h.toString()).toBe('<table><tr><td>Z<td>2</tr></table>');
+  });
+
+  test('innerHTML on first implicit <li> does not eat the next item', () => {
+    const h = new HtmlMod('<ul><li>a<li>b<li>c</ul>');
+    h.querySelectorAll('li')[0].innerHTML = 'X';
+    expect(h.toString()).toBe('<ul><li>X<li>b<li>c</ul>');
+  });
+
+  test('append on a middle implicit <li> inserts into that item', () => {
+    const h = new HtmlMod('<ul><li>a<li>b<li>c</ul>');
+    h.querySelectorAll('li')[1].append('!');
+    expect(h.toString()).toBe('<ul><li>a<li>b!<li>c</ul>');
+  });
+
+  test('last implicit <td> content boundary is still correct', () => {
+    const h = new HtmlMod('<table><tr><td>1<td>2</tr></table>');
+    h.querySelectorAll('td')[1].innerHTML = 'Y';
+    expect(h.toString()).toBe('<table><tr><td>1<td>Y</tr></table>');
+  });
+
+  test('innerHTML getter on implicit <td> with nested element', () => {
+    const h = new HtmlMod('<table><tr><td>a<b>x</b><td>2</tr></table>');
+    expect(h.querySelectorAll('td')[0].innerHTML).toBe('a<b>x</b>');
+    h.querySelectorAll('td')[0].append('<i>!</i>');
+    expect(h.toString()).toBe('<table><tr><td>a<b>x</b><i>!</i><td>2</tr></table>');
+  });
+
+  test('outerHTML of implicit <td> excludes the next cell', () => {
+    const h = new HtmlMod('<table><tr><td>1<td>2</tr></table>');
+    expect(h.querySelectorAll('td')[0].outerHTML).toBe('<td>1');
+  });
+
+  test('after() on implicit <td> inserts right after that cell', () => {
+    const h = new HtmlMod('<table><tr><td>1<td>2</tr></table>');
+    h.querySelectorAll('td')[0].after('<x>!</x>');
+    expect(h.toString()).toBe('<table><tr><td>1<x>!</x><td>2</tr></table>');
+  });
+
+  test('remove() on implicit <td> removes only that cell', () => {
+    const h = new HtmlMod('<table><tr><td>1<td>2</tr></table>');
+    h.querySelectorAll('td')[0].remove();
+    expect(h.toString()).toBe('<table><tr><td>2</tr></table>');
+  });
+
+  test('replaceWith() on implicit <td> replaces only that cell', () => {
+    const h = new HtmlMod('<table><tr><td>1<td>2</tr></table>');
+    h.querySelectorAll('td')[0].replaceWith('<td>NEW</td>');
+    expect(h.toString()).toBe('<table><tr><td>NEW</td><td>2</tr></table>');
+  });
+
+  test('remove() on implicit <li> removes only that item', () => {
+    const h = new HtmlMod('<ul><li>a<li>b</ul>');
+    h.querySelectorAll('li')[0].remove();
+    expect(h.toString()).toBe('<ul><li>b</ul>');
+  });
+
+  test('unclosed element at EOF still works (no regression)', () => {
+    const h = new HtmlMod('<div><p>hi');
+    h.querySelector('p')!.innerHTML = 'Y';
+    expect(h.toString()).toBe('<div><p>Y');
+    expect(h.querySelector('p')!.innerHTML).toBe('Y');
+  });
+});

--- a/packages/html-mod/src/index.ts
+++ b/packages/html-mod/src/index.ts
@@ -82,6 +82,57 @@ export class HtmlMod {
     // Note: __source is already up-to-date from string operations
   }
 
+  /**
+   * Reconcile the AST after leading characters were stripped from the source.
+   *
+   * The removed region (always whitespace for the trim methods) is a contiguous
+   * prefix occupied by root-level text node(s). Fully-removed text nodes are
+   * dropped from the AST; a straddling node has its leading data trimmed. Must
+   * run BEFORE the corresponding remove delta so the delta then fixes the
+   * straddling node's endIndex (its startIndex stays at the front).
+   */
+  __reconcileLeadingTrim(count: number): void {
+    let remaining = count;
+    const children = this.__dom.children;
+    while (remaining > 0 && children.length > 0) {
+      const node = children[0];
+      if (node.type !== 'text') break;
+      const dataLength = node.data.length;
+      if (dataLength <= remaining) {
+        children.shift();
+        remaining -= dataLength;
+      } else {
+        node.data = node.data.slice(remaining);
+        remaining = 0;
+      }
+    }
+  }
+
+  /**
+   * Reconcile the AST after trailing characters were stripped from the source.
+   *
+   * Mirror of __reconcileLeadingTrim for a contiguous suffix. A straddling node
+   * keeps its startIndex, so we fix its endIndex here (the remove delta won't —
+   * the node sits before the delta's mutation start).
+   */
+  __reconcileTrailingTrim(count: number): void {
+    let remaining = count;
+    const children = this.__dom.children;
+    while (remaining > 0 && children.length > 0) {
+      const node = children.at(-1);
+      if (node.type !== 'text') break;
+      const dataLength = node.data.length;
+      if (dataLength <= remaining) {
+        children.pop();
+        remaining -= dataLength;
+      } else {
+        node.data = node.data.slice(0, dataLength - remaining);
+        node.endIndex = node.startIndex + node.data.length - 1;
+        remaining = 0;
+      }
+    }
+  }
+
   trim() {
     const beforeSource = this.__source;
     const afterSource = beforeSource.trim();
@@ -93,11 +144,16 @@ export class HtmlMod {
       const trimmedStart = beforeSource.length - beforeSource.trimStart().length;
       const trimmedEnd = trimmedTotal - trimmedStart;
 
-      if (trimmedStart > 0) {
-        this.__trackDelta(calculateRemoveDelta(0, trimmedStart));
-      }
+      // Handle the trailing removal first so its delta is expressed in the
+      // original coordinate space; the leading delta then shifts everything
+      // (including the trailing-adjusted nodes) left uniformly.
       if (trimmedEnd > 0) {
+        this.__reconcileTrailingTrim(trimmedEnd);
         this.__trackDelta(calculateRemoveDelta(beforeSource.length - trimmedEnd, beforeSource.length));
+      }
+      if (trimmedStart > 0) {
+        this.__reconcileLeadingTrim(trimmedStart);
+        this.__trackDelta(calculateRemoveDelta(0, trimmedStart));
       }
     }
 
@@ -112,6 +168,7 @@ export class HtmlMod {
     // Queue delta for removed characters at start
     const trimmed = beforeSource.length - afterSource.length;
     if (trimmed > 0) {
+      this.__reconcileLeadingTrim(trimmed);
       this.__trackDelta(calculateRemoveDelta(0, trimmed));
     }
 
@@ -126,6 +183,7 @@ export class HtmlMod {
     // Queue delta for removed characters at end
     const trimmed = beforeSource.length - afterSource.length;
     if (trimmed > 0) {
+      this.__reconcileTrailingTrim(trimmed);
       this.__trackDelta(calculateRemoveDelta(beforeSource.length - trimmed, beforeSource.length));
     }
 
@@ -160,15 +218,19 @@ export class HtmlMod {
       this.__source = keepLines.join('\n');
     }
 
-    // Track deltas
-    if (trimmedStartLines > 0) {
-      const trimmedChars = beforeLines.slice(0, trimmedStartLines).join('\n').length + 1; // +1 for final newline
-      this.__trackDelta(calculateRemoveDelta(0, trimmedChars));
-    }
-
+    // Track deltas. Trailing first (original coordinates), then leading, so the
+    // leading delta shifts everything uniformly and the two removals don't
+    // interfere with each other's coordinates.
     if (trimmedEndLines > 0) {
       const startPos = beforeLines.slice(0, beforeLines.length - trimmedEndLines).join('\n').length;
+      this.__reconcileTrailingTrim(beforeSource.length - startPos);
       this.__trackDelta(calculateRemoveDelta(startPos, beforeSource.length));
+    }
+
+    if (trimmedStartLines > 0) {
+      const trimmedChars = beforeLines.slice(0, trimmedStartLines).join('\n').length + 1; // +1 for final newline
+      this.__reconcileLeadingTrim(trimmedChars);
+      this.__trackDelta(calculateRemoveDelta(0, trimmedChars));
     }
 
     return this;

--- a/packages/html-mod/src/index.ts
+++ b/packages/html-mod/src/index.ts
@@ -524,7 +524,10 @@ export class HtmlModElement {
         const tagEnd = this.__element.source.openTag.endIndex + 1;
         atomicOverwrite(this.__htmlMod, slashStart, tagEnd, `>${combined}`, this.__element);
       } else {
-        const insertPos = this.__element.source.openTag.endIndex;
+        // No trailing slash (e.g. void elements like <br>, <img src="a">):
+        // insert AFTER the `>` (endIndex + 1), not before it, or the content
+        // and synthesized close tag land inside the open tag.
+        const insertPos = this.__element.source.openTag.endIndex + 1;
         atomicAppendRight(this.__htmlMod, insertPos, combined, this.__element);
       }
     } else if (isEmpty) {
@@ -555,11 +558,13 @@ export class HtmlModElement {
 
       if (html.length > 0) {
         const closeTagStart = openTagEnd + 1 + html.length;
-        const closeTagEnd = closeTagStart + closingTag.length - 1;
+        // endIndex is exclusive (one past the `>`), matching the parser's convention
+        const closeTagEnd = closeTagStart + closingTag.length;
         AstManipulator.convertToRegularTag(this.__element, openTagEnd, closeTagStart, closeTagEnd);
       } else {
         const closeTagStart = openTagEnd + 1;
-        const closeTagEnd = closeTagStart + closingTag.length - 1;
+        // endIndex is exclusive (one past the `>`), matching the parser's convention
+        const closeTagEnd = closeTagStart + closingTag.length;
         AstManipulator.convertToRegularTag(this.__element, openTagEnd, closeTagStart, closeTagEnd);
       }
     }
@@ -619,6 +624,7 @@ export class HtmlModElement {
     const endIndex = this.__element.source.openTag.endIndex;
     const closeTag = makeClosingTag(this.tagName);
 
+    let openTagEnd: number;
     if (hasTrailingSlash(this.__element, this.__htmlMod.__source)) {
       // Replace ` />` or `/>` with `></tag>`
       // Walk back from `/` to skip whitespace before the slash
@@ -628,12 +634,20 @@ export class HtmlModElement {
         start--;
       }
       atomicOverwrite(this.__htmlMod, start, endIndex + 1, `>${closeTag}`, this.__element);
+      // The new `>` lands where the `/` (and any preceding spaces) began.
+      openTagEnd = start;
     } else {
       atomicAppendRight(this.__htmlMod, endIndex + 1, closeTag, this.__element);
+      // The `>` is unchanged.
+      openTagEnd = endIndex;
     }
 
-    // Update the AST to reflect the element is no longer self-closing
-    this.__element.source.openTag.isSelfClosing = false;
+    // Fully sync the AST to reflect the new explicit close tag: update the
+    // open-tag end, attach the close tag, and fix element.endIndex. Leaving any
+    // of these stale corrupts a later before()/after()/append()/innerHTML.
+    const closeTagStart = openTagEnd + 1;
+    const closeTagEnd = closeTagStart + closeTag.length; // exclusive, matches parser
+    AstManipulator.convertToRegularTag(this.__element, openTagEnd, closeTagStart, closeTagEnd);
 
     return this;
   }
@@ -698,15 +712,20 @@ export class HtmlModElement {
     }
 
     if (selfClosing) {
-      const parsePos = originalEndIndex + 1;
+      // When the tag had a trailing slash, the overwrite replaced `/>` with a
+      // single `>`, shifting the `>` (and therefore the inserted content) left
+      // by one. parsePos must be derived from the post-overwrite open-tag end,
+      // not the original `>` position, or every inserted position drifts.
       const openTagEnd = hadSlash ? originalEndIndex - 1 : originalEndIndex;
+      const parsePos = openTagEnd + 1;
 
       const newNodes = AstManipulator.parseHtmlAtPosition(html, parsePos, this.__htmlMod.__options);
       AstManipulator.prependChild(this.__element, newNodes);
 
       const closingTag = makeClosingTag(this.__element.tagName);
       const closeTagStart = parsePos + html.length;
-      const closeTagEnd = closeTagStart + closingTag.length - 1;
+      // endIndex is exclusive (one past the `>`), matching the parser's convention
+      const closeTagEnd = closeTagStart + closingTag.length;
       AstManipulator.convertToRegularTag(this.__element, openTagEnd, closeTagStart, closeTagEnd);
     } else {
       const insertPos = originalEndIndex + 1;

--- a/packages/html-mod/src/index.ts
+++ b/packages/html-mod/src/index.ts
@@ -13,7 +13,14 @@ import { decode } from 'html-entities';
 
 import * as AstManipulator from './ast-manipulator';
 import { AstUpdater } from './ast-updater';
-import { getContentStart, getContentEnd, makeClosingTag, isSelfClosing, hasTrailingSlash } from './element-utils';
+import {
+  getContentStart,
+  getContentEnd,
+  getOuterEnd,
+  makeClosingTag,
+  isSelfClosing,
+  hasTrailingSlash,
+} from './element-utils';
 import { calculateRemoveDelta, type PositionDelta } from './position-delta';
 import { atomicOverwrite, atomicAppendRight, atomicPrependLeft, atomicRemove } from './string-operations';
 
@@ -120,14 +127,16 @@ export class HtmlMod {
     const children = this.__dom.children;
     while (remaining > 0 && children.length > 0) {
       const node = children.at(-1);
-      if (node.type !== 'text') break;
+      if (!node || node.type !== 'text') break;
       const dataLength = node.data.length;
       if (dataLength <= remaining) {
         children.pop();
         remaining -= dataLength;
       } else {
         node.data = node.data.slice(0, dataLength - remaining);
-        node.endIndex = node.startIndex + node.data.length - 1;
+        if (node.startIndex != null) {
+          node.endIndex = node.startIndex + node.data.length - 1;
+        }
         remaining = 0;
       }
     }
@@ -398,7 +407,7 @@ export class HtmlModElement {
 
   get sourceRange() {
     const startIndex = this.__element.source.openTag.startIndex;
-    const endIndex = this.__element.source.closeTag?.endIndex ?? this.__element.endIndex + 1;
+    const endIndex = getOuterEnd(this.__element);
     const html = this.__htmlMod.__source;
 
     // count the lines before this element
@@ -556,10 +565,7 @@ export class HtmlModElement {
       return '';
     }
 
-    return this.__htmlMod.__source.slice(
-      this.__element.source.openTag.endIndex + 1,
-      this.__element?.source?.closeTag?.startIndex ?? this.__element.endIndex
-    );
+    return this.__htmlMod.__source.slice(getContentStart(this.__element), getContentEnd(this.__element));
   }
 
   set innerHTML(html: string) {
@@ -653,10 +659,7 @@ export class HtmlModElement {
       return cached;
     }
 
-    return this.__htmlMod.__source.slice(
-      this.__element.source.openTag.startIndex,
-      this.__element.source.closeTag?.endIndex ?? this.__element.endIndex + 1
-    );
+    return this.__htmlMod.__source.slice(this.__element.source.openTag.startIndex, getOuterEnd(this.__element));
   }
 
   /**
@@ -740,7 +743,7 @@ export class HtmlModElement {
   }
 
   after(html: string) {
-    const insertPos = this.__element.source.closeTag?.endIndex ?? this.__element.endIndex + 1;
+    const insertPos = getOuterEnd(this.__element);
 
     atomicAppendRight(this.__htmlMod, insertPos, html, this.__element);
 
@@ -819,17 +822,11 @@ export class HtmlModElement {
       // Only cache if not already cached
       if (!this.__htmlMod.__cachedInnerHTML.has(node)) {
         // Read innerHTML directly from source before it changes
-        const innerHTML = this.__htmlMod.__source.slice(
-          node.source.openTag.endIndex + 1,
-          node?.source?.closeTag?.startIndex ?? node.endIndex
-        );
+        const innerHTML = this.__htmlMod.__source.slice(getContentStart(node), getContentEnd(node));
         this.__htmlMod.__cachedInnerHTML.set(node, innerHTML);
 
         // Also cache outerHTML
-        const outerHTML = this.__htmlMod.__source.slice(
-          node.source.openTag.startIndex,
-          node.source.closeTag?.endIndex ?? node.endIndex + 1
-        );
+        const outerHTML = this.__htmlMod.__source.slice(node.source.openTag.startIndex, getOuterEnd(node));
         this.__htmlMod.__cachedOuterHTML.set(node, outerHTML);
 
         this.__removed = true;
@@ -856,10 +853,7 @@ export class HtmlModElement {
     this.__cacheDescendantsInnerHTML();
 
     const removeStart = this.__element.source.openTag.startIndex;
-    const removeEnd = Math.min(
-      this.__element.source.closeTag?.endIndex ?? this.__element.endIndex + 1,
-      this.__htmlMod.__source.length
-    );
+    const removeEnd = Math.min(getOuterEnd(this.__element), this.__htmlMod.__source.length);
 
     atomicRemove(this.__htmlMod, removeStart, removeEnd, this.__element);
 
@@ -876,10 +870,7 @@ export class HtmlModElement {
     this.__cacheDescendantsInnerHTML();
 
     const replaceStart = this.__element.source.openTag.startIndex;
-    const replaceEnd = Math.min(
-      this.__element.source.closeTag?.endIndex ?? this.__element.endIndex + 1,
-      this.__htmlMod.__source.length
-    );
+    const replaceEnd = Math.min(getOuterEnd(this.__element), this.__htmlMod.__source.length);
 
     atomicOverwrite(this.__htmlMod, replaceStart, replaceEnd, html, this.__element);
 

--- a/packages/html-mod/src/index.ts
+++ b/packages/html-mod/src/index.ts
@@ -1141,7 +1141,9 @@ export class HtmlModText {
   }
 
   set innerHTML(html: string) {
-    if (!this.__text.endIndex) {
+    // Guard against an unpositioned node, but allow endIndex === 0 (a one-char
+    // text node at the very start of the document) — `!0` would drop the write.
+    if (this.__text.endIndex == null) {
       return;
     }
 
@@ -1156,7 +1158,8 @@ export class HtmlModText {
   }
 
   set textContent(text: string) {
-    if (!this.__text.endIndex) {
+    // Allow endIndex === 0 (one-char text node at index 0); `!0` would drop it.
+    if (this.__text.endIndex == null) {
       return;
     }
 

--- a/packages/html-mod/src/self-closing-position-drift.test.ts
+++ b/packages/html-mod/src/self-closing-position-drift.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression tests for position drift / data corruption when prepend/append
+ * is used on self-closing elements written with a trailing slash (e.g.
+ * `<img src="y"/>`).
+ *
+ * The overwrite that replaces `/>` with `>` shifts the `>` left by one
+ * character. If the AST positions for the newly inserted children (and the
+ * synthesized close tag) are computed from the original `>` position instead
+ * of the shifted one, every position is off-by-one and the next mutation
+ * corrupts the string.
+ */
+import { describe, expect, test } from 'vitest';
+
+import { HtmlMod } from './index';
+
+describe('self-closing trailing-slash position drift', () => {
+  test('append then setAttribute on the new child does not corrupt', () => {
+    const h = new HtmlMod('<section><img src="y"/></section>');
+    h.querySelector('img')!.append('<b>hi</b>');
+    expect(h.toString()).toBe('<section><img src="y"><b>hi</b></img></section>');
+
+    const b = h.querySelector('b')!;
+    // outerHTML is derived purely from tracked positions
+    expect(b.outerHTML).toBe('<b>hi</b>');
+
+    b.setAttribute('id', 'x');
+    expect(h.toString()).toBe('<section><img src="y"><b id="x">hi</b></img></section>');
+  });
+
+  test('prepend then setAttribute on the new child does not corrupt', () => {
+    const h = new HtmlMod('<section><img src="y"/></section>');
+    h.querySelector('img')!.prepend('<b>hi</b>');
+    expect(h.toString()).toBe('<section><img src="y"><b>hi</b></img></section>');
+
+    const b = h.querySelector('b')!;
+    expect(b.outerHTML).toBe('<b>hi</b>');
+
+    b.setAttribute('id', 'x');
+    expect(h.toString()).toBe('<section><img src="y"><b id="x">hi</b></img></section>');
+  });
+
+  test('append then remove the new child removes the right bytes', () => {
+    const h = new HtmlMod('<section><img src="y"/></section>');
+    h.querySelector('img')!.append('<b>hi</b>');
+    h.querySelector('b')!.remove();
+    expect(h.toString()).toBe('<section><img src="y"></img></section>');
+  });
+
+  test('synthesized close tag position is correct after append', () => {
+    const h = new HtmlMod('<img src="y"/>');
+    const img = h.querySelector('img')!;
+    img.append('<b>hi</b>');
+    // The close tag position is tracked; outerHTML uses closeTag.endIndex
+    expect(img.outerHTML).toBe('<img src="y"><b>hi</b></img>');
+  });
+
+  test('expandSelfClosing (slash) then append does not corrupt', () => {
+    const h = new HtmlMod('<wrap><x-card title="t"/></wrap>');
+    h.querySelector('x-card')!.expandSelfClosing();
+    expect(h.toString()).toBe('<wrap><x-card title="t"></x-card></wrap>');
+    expect(h.querySelector('x-card')!.outerHTML).toBe('<x-card title="t"></x-card>');
+
+    h.querySelector('x-card')!.append('<b>hi</b>');
+    expect(h.toString()).toBe('<wrap><x-card title="t"><b>hi</b></x-card></wrap>');
+  });
+
+  test('expandSelfClosing (slash) then after does not corrupt', () => {
+    const h = new HtmlMod('<wrap><x-card title="t"/></wrap>');
+    h.querySelector('x-card')!.expandSelfClosing();
+    h.querySelector('x-card')!.after('<z>S</z>');
+    expect(h.toString()).toBe('<wrap><x-card title="t"></x-card><z>S</z></wrap>');
+  });
+
+  test('expandSelfClosing (void, no slash) then after does not corrupt', () => {
+    const h = new HtmlMod('<div><br></div>');
+    h.querySelector('br')!.expandSelfClosing();
+    expect(h.toString()).toBe('<div><br></br></div>');
+    h.querySelector('br')!.after('<z>S</z>');
+    expect(h.toString()).toBe('<div><br></br><z>S</z></div>');
+  });
+
+  test('expandSelfClosing (slash + space) then after does not corrupt', () => {
+    const h = new HtmlMod('<wrap><x-card title="t" /></wrap>');
+    h.querySelector('x-card')!.expandSelfClosing();
+    expect(h.toString()).toBe('<wrap><x-card title="t"></x-card></wrap>');
+    h.querySelector('x-card')!.after('<z>S</z>');
+    expect(h.toString()).toBe('<wrap><x-card title="t"></x-card><z>S</z></wrap>');
+  });
+
+  test('innerHTML on void tag without slash does not corrupt', () => {
+    const h = new HtmlMod('<div><br></div>');
+    h.querySelector('br')!.innerHTML = 'x';
+    expect(h.toString()).toBe('<div><br>x</br></div>');
+  });
+
+  test('innerHTML (empty) on void tag without slash does not corrupt', () => {
+    const h = new HtmlMod('<div><br></div>');
+    h.querySelector('br')!.innerHTML = '';
+    expect(h.toString()).toBe('<div><br></br></div>');
+  });
+
+  test('innerHTML on no-slash self-closing with attributes does not corrupt', () => {
+    const h = new HtmlMod('<div><img src="a"></div>');
+    h.querySelector('img')!.innerHTML = 'x';
+    expect(h.toString()).toBe('<div><img src="a">x</img></div>');
+  });
+
+  test('textContent on slash tag then append keeps close tag tracked', () => {
+    const h = new HtmlMod('<x-card title="t"/>');
+    h.querySelector('x-card')!.textContent = 't40';
+    h.querySelector('x-card')!.append('<b>a41</b>');
+    expect(h.toString()).toBe('<x-card title="t">t40<b>a41</b></x-card>');
+    // outerHTML is derived from tracked positions — must include the close tag
+    expect(h.querySelector('x-card')!.outerHTML).toBe('<x-card title="t">t40<b>a41</b></x-card>');
+  });
+
+  test('innerHTML on slash tag then after() does not corrupt (endIndex tracked)', () => {
+    const h = new HtmlMod('<wrap><x-card title="t"/></wrap>');
+    h.querySelector('x-card')!.innerHTML = 'hi';
+    h.querySelector('x-card')!.after('<z>S</z>');
+    expect(h.toString()).toBe('<wrap><x-card title="t">hi</x-card><z>S</z></wrap>');
+  });
+
+  test('innerHTML on self-closing then after() does not corrupt', () => {
+    const h = new HtmlMod('<wrap><img src="y"/></wrap>');
+    h.querySelector('img')!.innerHTML = 'hi';
+    expect(h.toString()).toBe('<wrap><img src="y">hi</img></wrap>');
+
+    const img = h.querySelector('img')!;
+    expect(img.outerHTML).toBe('<img src="y">hi</img>');
+
+    img.after('<z>S</z>');
+    expect(h.toString()).toBe('<wrap><img src="y">hi</img><z>S</z></wrap>');
+  });
+
+  test('innerHTML on self-closing (empty) then after() does not corrupt', () => {
+    const h = new HtmlMod('<wrap><img src="y"/></wrap>');
+    h.querySelector('img')!.innerHTML = '';
+    expect(h.toString()).toBe('<wrap><img src="y"></img></wrap>');
+
+    h.querySelector('img')!.after('<z>S</z>');
+    expect(h.toString()).toBe('<wrap><img src="y"></img><z>S</z></wrap>');
+  });
+
+  test('append on trailing-slash with space then mutate child', () => {
+    const h = new HtmlMod('<wrap><x-img src="y" /></wrap>');
+    h.querySelector('x-img')!.append('<b>hi</b>');
+    // The space before the slash is preserved (valid HTML); positions must
+    // still be correct so the follow-up mutation lands in the right place.
+    expect(h.toString()).toBe('<wrap><x-img src="y" ><b>hi</b></x-img></wrap>');
+    h.querySelector('b')!.setAttribute('id', 'z');
+    expect(h.toString()).toBe('<wrap><x-img src="y" ><b id="z">hi</b></x-img></wrap>');
+  });
+});

--- a/packages/html-mod/src/trim-ast-sync.test.ts
+++ b/packages/html-mod/src/trim-ast-sync.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression tests: trim()/trimStart()/trimEnd()/trimLines() must keep the AST
+ * in sync with the trimmed source string. Previously the trimmed boundary
+ * whitespace was removed from the string but the corresponding text nodes were
+ * left in the AST with stale data and positions (phantom nodes overlapping
+ * elements, or text data still containing the trimmed whitespace).
+ *
+ * toString() reads __source directly so it always looked right; the corruption
+ * surfaced through any AST-backed read (children, textContent) or a follow-up
+ * mutation.
+ */
+import { describe, expect, test } from 'vitest';
+
+import { HtmlMod } from './index';
+
+// Every root-level text node's data must equal the source slice at its tracked
+// position, and children must be ordered/non-overlapping.
+function assertInSync(h: HtmlMod) {
+  const source = (h as unknown as { __source: string }).__source;
+  const dom = (h as unknown as { __dom: { children: any[] } }).__dom;
+  let previousEnd = -1;
+  for (const node of dom.children) {
+    if (node.startIndex != null && node.endIndex != null) {
+      expect(node.startIndex).toBeGreaterThan(previousEnd);
+      previousEnd = node.endIndex;
+      if (node.type === 'text') {
+        expect(source.slice(node.startIndex, node.endIndex + 1)).toBe(node.data);
+      }
+      if (node.type === 'tag') {
+        expect(source[node.source.openTag.startIndex]).toBe('<');
+      }
+    }
+  }
+}
+
+describe('trim AST sync', () => {
+  test('trim removes leading and trailing whitespace text nodes from AST', () => {
+    const h = new HtmlMod('\n\n<div>x</div>\n\n');
+    h.trim();
+    expect(h.toString()).toBe('<div>x</div>');
+    const children = (h as any).__dom.children;
+    expect(children.filter((c: any) => c.type === 'text')).toHaveLength(0);
+    expect(children.filter((c: any) => c.type === 'tag')).toHaveLength(1);
+    assertInSync(h);
+  });
+
+  test('trimStart trims a straddling boundary text node data', () => {
+    const h = new HtmlMod('  abc<div>x</div>');
+    h.trimStart();
+    expect(h.toString()).toBe('abc<div>x</div>');
+    const first = (h as any).__dom.children[0];
+    expect(first.type).toBe('text');
+    expect(first.data).toBe('abc');
+    assertInSync(h);
+  });
+
+  test('trimEnd trims a straddling trailing text node data', () => {
+    const h = new HtmlMod('<div>x</div>abc  ');
+    h.trimEnd();
+    expect(h.toString()).toBe('<div>x</div>abc');
+    const last = (h as any).__dom.children.at(-1);
+    expect(last.type).toBe('text');
+    expect(last.data).toBe('abc');
+    assertInSync(h);
+  });
+
+  test('trim then before() keeps positions correct', () => {
+    const h = new HtmlMod('   <div>x</div>   ');
+    h.trim();
+    h.querySelector('div')!.before('<a>Y</a>');
+    expect(h.toString()).toBe('<a>Y</a><div>x</div>');
+    assertInSync(h);
+  });
+
+  test('trim then setAttribute on element does not corrupt', () => {
+    const h = new HtmlMod('\n  <div>x</div>\n  ');
+    h.trim();
+    h.querySelector('div')!.setAttribute('id', 'z');
+    expect(h.toString()).toBe('<div id="z">x</div>');
+    assertInSync(h);
+  });
+
+  test('trimLines removes blank lines and keeps AST in sync', () => {
+    const h = new HtmlMod('\n\n<div>x</div>\n\n');
+    h.trimLines();
+    expect(h.toString()).toBe('<div>x</div>');
+    expect((h as any).__dom.children.filter((c: any) => c.type === 'text')).toHaveLength(0);
+    assertInSync(h);
+  });
+
+  test('trimLines then mutation does not corrupt (both ends trimmed)', () => {
+    const h = new HtmlMod('\n\n  <section><p>hi</p></section>  \n\n');
+    h.trimLines();
+    h.querySelector('p')!.setAttribute('class', 'c');
+    assertInSync(h);
+    expect(h.querySelector('p')!.outerHTML).toBe('<p class="c">hi</p>');
+  });
+
+  test('parent textContent reflects trimmed content, not stale whitespace', () => {
+    const h = new HtmlMod('  abc<b>x</b>  ');
+    h.trim();
+    // Root-level text node should now read "abc", not "  abc"
+    const textNode = (h as any).__dom.children.find((c: any) => c.type === 'text');
+    expect(textNode.data).toBe('abc');
+    assertInSync(h);
+  });
+
+  test('whole-document whitespace trims to empty without phantom nodes', () => {
+    const h = new HtmlMod('   \n  ');
+    h.trim();
+    expect(h.toString()).toBe('');
+    expect((h as any).__dom.children.filter((c: any) => c.type === 'text' && c.data.length > 0)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Fixes a class of position-drift data corruption in `html-mod` affecting **self-closing tags**. When an element written as self-closing (`<img src="y"/>`, void `<br>`/`<hr>`, or a custom `<x-card ... />`) was mutated, the tracked AST positions could fall out of sync with the source string. The string write itself looked right, but the next edit then wrote bytes to the wrong place.

## Bugs found & fixed

Each is proven by a failing-before/passing-after test in `self-closing-position-drift.test.ts`.

1. **`prepend`/`append` on a trailing-slash tag** — child + close-tag positions were derived from the pre-overwrite `>` index, which shifts left by one when `/>` becomes `>`. Off-by-one drift → e.g. `b.setAttribute('id','x')` produced `<b> id="x">hi</b>`.
2. **`convertToRegularTag` close-tag `endIndex`** — set inclusively, but the parser and every reader (`outerHTML`, `after`, `remove`) treat it as exclusive. Truncated `outerHTML` and mis-placed `after()`/`remove()`.
3. **`innerHTML`/`textContent` on a void/no-slash self-closing tag** (`<br>`, `<img src=a>`) — inserted content *before* the `>` → `<brx</br>>`.
4. **Stale `element.endIndex` after conversion** — a later op whose mutation started past the stale `endIndex` short-circuited and skipped updating the close tag.
5. **`expandSelfClosing`** — rewrote the string but never updated `openTag.endIndex`, attached a `closeTag`, or fixed `element.endIndex`, so a later `before/after/append` corrupted the document.

## Verification

- New `self-closing-position-drift.test.ts` (16 cases) covers each bug.
- Full suite: **546 passing**, `tsc --noEmit` clean.
- Property fuzzing (position invariants): **0 failures over 40k random op-sequences** with the stricter validator, plus **0 over 20k multibyte sequences**. Pre-fix, the same fuzzer reported hundreds of corruptions.

## Notes / out of scope

`setAttribute(x, v)`→`getAttribute(x)` does not round-trip when `v` literally contains `&quot;`/`&#39;`. This matches browser entity-decoding semantics for the emitted source, and "fixing" it would require escaping `&` in all attribute values — breaking the library's minimal-change guarantee for URLs and Liquid/Handlebars. Left as a documented limitation.
