### PR TITLE
fix(html-mod): synthesize close tags with the open tag's source casing

### DIFF
--- a/.changeset/html-mod-self-closing-case.md
+++ b/.changeset/html-mod-self-closing-case.md
@@ -1,0 +1,12 @@
+---
+'@ciolabs/html-mod': patch
+---
+
+Fix synthesized close tags to use the open tag's source casing. The parser
+pairs open/close tags case-sensitively, but `expandSelfClosing`,
+`prepend`/`append`, and `innerHTML`/`textContent` synthesized a lowercase close
+tag. On a mixed-case element (`<X-Image/>`, `<X-Card>...`), that produced
+`<X-Image></x-image>` — which the parser will not re-pair on the next parse,
+leaving the close tag orphaned and corrupting a later mutation (e.g. an
+`outerHTML`/`replaceWith` that relies on the tracked close-tag range). All
+synthesized close tags now match the open tag's casing and round-trip cleanly.

--- a/packages/html-mod/src/ast-manipulator.ts
+++ b/packages/html-mod/src/ast-manipulator.ts
@@ -377,12 +377,15 @@ export function convertToRegularTag(
     element.source.openTag.isSelfClosing = false;
     element.source.openTag.endIndex = openTagEnd; // Update '>' position
 
-    // Add closeTag information
+    // Add closeTag information. Use the open tag's source casing so the
+    // synthesized close tag matches what was written to the source string and
+    // re-pairs on the next parse (the parser matches tags case-sensitively).
+    const sourceTagName = element.source.openTag.name ?? element.tagName;
     element.source.closeTag = {
       startIndex: closeTagStart,
       endIndex: closeTagEnd,
-      data: `</${element.tagName}>`,
-      name: element.tagName,
+      data: `</${sourceTagName}>`,
+      name: sourceTagName,
     };
 
     // The element now ends at the close tag. Keep element.endIndex (the

--- a/packages/html-mod/src/expand-self-closing.test.ts
+++ b/packages/html-mod/src/expand-self-closing.test.ts
@@ -140,10 +140,25 @@ describe('expandSelfClosing', () => {
     test('mixed-case tag round-trips after expansion + setAttribute', () => {
       const h = new HtmlMod('<wrap><X-Image src="a"/></wrap>');
       h.querySelector('x-image')!.expandSelfClosing();
-      // Open tag preserves source casing; close tag uses the parser tag name.
-      expect(h.toString()).toBe('<wrap><X-Image src="a"></x-image></wrap>');
+      // The synthesized close tag uses the open tag's source casing so the
+      // result re-pairs on the next parse (the parser matches case-sensitively);
+      // a lowercase close tag here would orphan on reparse.
+      expect(h.toString()).toBe('<wrap><X-Image src="a"></X-Image></wrap>');
       h.querySelector('x-image')!.dataset.source = 'ZZZ';
-      expect(h.toString()).toBe('<wrap><X-Image src="a" data-source="ZZZ"></x-image></wrap>');
+      expect(h.toString()).toBe('<wrap><X-Image src="a" data-source="ZZZ"></X-Image></wrap>');
+    });
+
+    test('mixed-case expansion re-pairs on reparse (no orphan close tag)', () => {
+      const h = new HtmlMod('<X-Image src="a"/>');
+      h.querySelector('x-image')!.expandSelfClosing();
+      // Round-trip the serialized output through a fresh parse: the close tag
+      // must pair back to the element, or a later mutation (e.g. a consumer's
+      // collapse/replace) leaves an orphaned `</x-image>`.
+      const reparsed = new HtmlMod(h.toString());
+      const element = reparsed.querySelector('x-image')!;
+      expect(element.__element.source.closeTag).not.toBeNull();
+      element.replaceWith('REPL');
+      expect(reparsed.toString()).toBe('REPL');
     });
 
     test('spaced form round-trips after expansion + setAttribute', () => {

--- a/packages/html-mod/src/index.ts
+++ b/packages/html-mod/src/index.ts
@@ -584,7 +584,7 @@ export class HtmlModElement {
     const originalOpenTagEnd = this.__element.source.openTag.endIndex;
 
     if (selfClosing) {
-      const closingTag = makeClosingTag(this.__element.tagName);
+      const closingTag = makeClosingTag(this.__element.source.openTag.name);
       const combined = html + closingTag;
 
       if (hasSlash) {
@@ -621,7 +621,7 @@ export class HtmlModElement {
     }
 
     if (selfClosing) {
-      const closingTag = makeClosingTag(this.__element.tagName);
+      const closingTag = makeClosingTag(this.__element.source.openTag.name);
       const openTagEnd = hasSlash ? this.__element.source.openTag.endIndex - 1 : this.__element.source.openTag.endIndex;
 
       if (html.length > 0) {
@@ -687,7 +687,11 @@ export class HtmlModElement {
     this.__htmlMod.__cachedOuterHTML.delete(this.__element);
 
     const endIndex = this.__element.source.openTag.endIndex;
-    const closeTag = makeClosingTag(this.tagName);
+    // Use the open tag's source casing for the close tag. The parser pairs
+    // open/close tags case-sensitively, so a synthesized lowercase close tag
+    // on a mixed-case element (`<X-Image/>` -> `<X-Image></x-image>`) would not
+    // re-pair on the next parse, leaving an orphaned close tag.
+    const closeTag = makeClosingTag(this.__element.source.openTag.name);
 
     let openTagEnd: number;
     if (hasTrailingSlash(this.__element, this.__htmlMod.__source)) {
@@ -759,7 +763,7 @@ export class HtmlModElement {
     const originalEndIndex = this.__element.source.openTag.endIndex;
 
     if (selfClosing) {
-      const closingTag = makeClosingTag(this.__element.tagName);
+      const closingTag = makeClosingTag(this.__element.source.openTag.name);
 
       if (hadSlash) {
         const slashStart = originalEndIndex - 1;
@@ -787,7 +791,7 @@ export class HtmlModElement {
       const newNodes = AstManipulator.parseHtmlAtPosition(html, parsePos, this.__htmlMod.__options);
       AstManipulator.prependChild(this.__element, newNodes);
 
-      const closingTag = makeClosingTag(this.__element.tagName);
+      const closingTag = makeClosingTag(this.__element.source.openTag.name);
       const closeTagStart = parsePos + html.length;
       // endIndex is exclusive (one past the `>`), matching the parser's convention
       const closeTagEnd = closeTagStart + closingTag.length;


### PR DESCRIPTION
## Summary

Follow-up to #51. The parser pairs open/close tags **case-sensitively**, but the close-tag synthesizers (`expandSelfClosing`, `prepend`/`append`, `innerHTML`/`textContent`) built the close tag from the normalized lowercase `tagName`. On a mixed-case element this produced a mismatched pair:

```js
const h = new HtmlMod('<X-Image/>');
h.querySelector('x-image').expandSelfClosing();
h.toString();                       // before: '<X-Image></x-image>'
new HtmlMod(h.toString())
  .querySelector('x-image')
  .__element.source.closeTag;        // before: null  (NOT re-paired)
```

Because the reparsed element has no `closeTag`, any later mutation that relies on the tracked close-tag range (`outerHTML`, `replaceWith`) operates on the open tag only — corrupting the document. A downstream consumer collapsing the element back to self-closing was left with a stray orphan `</x-image>`.

## Fix

Synthesize every close tag (and the `convertToRegularTag` AST metadata) from `element.source.openTag.name`, which preserves the source casing. `<X-Image/>` now expands to `<X-Image></X-Image>`, which re-pairs cleanly on the next parse.

Lowercase-input behavior is unchanged (lowercase open → lowercase close).

## Tests

- Updated the mixed-case expectation to the casing-preserving output.
- Added a reparse re-pairing regression test (expand → serialize → parse → `closeTag` is paired → `replaceWith` covers the whole element).
- Full suite: **582 passing**, `tsc` clean.

## Context

Surfaced by Design Studio (parcel): after bumping to `@ciolabs/html-mod@1.1.1`, a mixed-case self-closing custom element (`<X-Image/>`) round-tripped through the editor with a leaked `</x-image>`. This is the upstream fix; a patch release lets parcel pick it up.