### PR TITLE
ci: pin release npm to 11.x (npm@latest 12.x drops Node 20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@ciolabs'
 
+      # npm@latest is 12.x, which requires Node >=22.22 and breaks on the
+      # Node 20 runner below. npm 11.x still satisfies the OIDC requirement
+      # (>= 11.5.1) and supports Node 20 — pin to it rather than track the
+      # newest major into the publish pipeline.
       - name: Install npm 11.5.1+ for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Problem

The Release workflow is failing at the **"Install npm 11.5.1+ for OIDC support"** step for every release — including the `batch()` merge (#58), which itself built and tested clean. It dies before `changeset:version`/`publish` ever run, so no version PR is created and nothing publishes.

Root cause is external: `npm install -g npm@latest` now resolves to **npm 12.0.1**, whose new engine requirement dropped Node 20:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

The workflow runs Node 20 (release.yml:31), so the upgrade to npm 12 can't install. Recent releases (#56, #57) passed because npm 12 hadn't shipped yet.

## Fix

Pin the upgrade to `npm@11` instead of `npm@latest`. The step only needs **≥ 11.5.1** for OIDC trusted publishing; npm 11.x satisfies that and supports Node 20 (`^20.17.0 || >=22.9.0`), so this restores the exact behavior that worked until npm 12 dropped — no Node bump, no brand-new npm major in the publish pipeline.

```diff
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
```

## Alternative considered

Bumping the runner to Node 22 (which would let `npm@latest`/12.x install) is the more future-proof change, but it drags a Node version bump and a day-old npm major into the publish path — larger blast radius than warranted for unblocking the release. Worth doing separately (ci.yml is still on Node 18, also EOL); keeping this PR minimal and targeted.

## Testing

Config-only change to the release workflow; verifiable on the next release run. Once merged, the pending `@ciolabs/html-mod` 1.2.0 release (the `batch()` changeset from #58) should version + publish normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
