### PR TITLE
ci: grant statuses:write for release PR auto-pass step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
+      # The "Auto-pass required checks" step POSTs a commit status on the
+      # release PR, which needs statuses:write. Default GITHUB_TOKEN perms
+      # don't include it, so the POST 403s ("Resource not accessible by
+      # integration").
+      statuses: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Follow-up to #59. With the npm-engine fix in, the Release workflow now gets far enough to **create the version PR** (#60, "chore: release packages" — the pending `@ciolabs/html-mod` 1.2.0 bump). But the next step, **"Auto-pass required checks for release PR"**, fails with a 403:

```
POST repos/customerio/ciolabs/statuses/$HEAD_SHA
gh: Resource not accessible by integration (HTTP 403)
{"message":"Resource not accessible by integration", ... "status":"403"}
```

That step POSTs a commit status (`context=Test`) to green the required check on the release PR so it can merge. Posting a commit status requires `statuses: write`, but the job's `permissions:` block only grants `id-token`, `contents`, and `pull-requests` — so the default `GITHUB_TOKEN` can't write the status.

## Fix

Add `statuses: write` to the job permissions.

```diff
     permissions:
       id-token: write
       contents: write
       pull-requests: write
+      statuses: write
```

## Testing

Config-only. On the next Release run (this merge to main), the auto-pass step should post the `Test` status successfully, unblocking the version PR. Once #60 (or its regenerated equivalent) merges, `@ciolabs/html-mod@1.2.0` with `batch()` publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
