### PR TITLE
feat(html-mod): make expandSelfClosing() batch-aware

### DIFF
--- a/.changeset/expand-self-closing-batch.md
+++ b/.changeset/expand-self-closing-batch.md
@@ -1,0 +1,11 @@
+---
+'@ciolabs/html-mod': minor
+---
+
+Make `expandSelfClosing()` batch-aware.
+
+Inside `batch()`, `expandSelfClosing()` now queues its edit (the ` />` → `></tag>` rewrite plus the AST convert-to-regular-tag) and applies it at flush, instead of an O(document) splice + AST walk per call. Expanding every self-closing element in a large document drops from quadratic to one rebuild + one AST pass.
+
+`expandSelfClosing` is treated as a "structural" batch kind: it conflicts with any other queued edit on the same element (both touch the open-tag boundary), so a mixed sequence like `setAttribute(...)` then `expandSelfClosing()` on one element flushes between them — identical output to unbatched. Callers wanting the batched win should apply attribute marks and expansions in separate batched passes over distinct elements. `isSelfClosing` / `children` / `textContent` reads flush a pending expand so they never observe stale structure.
+
+Measured (43KB document, 400 self-closing elements, two batched passes): 26ms → 2.3ms (11×), and batched time scales linearly with document size.

--- a/packages/html-mod/src/batch-structural.test.ts
+++ b/packages/html-mod/src/batch-structural.test.ts
@@ -309,6 +309,27 @@ describe('expandSelfClosing batch equivalence', () => {
     });
     expect(h.toString()).toBe('<x-a></x-a><x-b />');
   });
+
+  test('expand then setAttribute on the same element (symmetric to attr+expand)', () => {
+    // The queued expand converts the element out of self-closing; a following
+    // setAttribute on it must flush first (structural conflict) and then add
+    // the attribute to the now-regular tag — byte-identical to eager order.
+    const source = '<x-a /><x-b />';
+    const eager = new HtmlMod(source);
+    for (const element of eager.querySelectorAll('x-a, x-b')) {
+      element.expandSelfClosing();
+      element.setAttribute('data-k', element.tagName);
+    }
+    const batched = new HtmlMod(source);
+    batched.batch(() => {
+      for (const element of batched.querySelectorAll('x-a, x-b')) {
+        element.expandSelfClosing();
+        element.setAttribute('data-k', element.tagName);
+      }
+    });
+    expect(batched.toString()).toBe(eager.toString());
+    expect(positionSnapshot(batched)).toBe(positionSnapshot(eager));
+  });
 });
 
 describe('structural batch guards', () => {

--- a/packages/html-mod/src/batch-structural.test.ts
+++ b/packages/html-mod/src/batch-structural.test.ts
@@ -231,6 +231,86 @@ describe('structural batch equivalence', () => {
   });
 });
 
+const VOID_TAGS = new Set(['img', 'br', 'hr', 'input']);
+
+function expandableSelfClosing(element: ReturnType<HtmlMod['querySelectorAll']>[number]): boolean {
+  return element.isSelfClosing && !VOID_TAGS.has(element.tagName.toLowerCase());
+}
+
+function expandAllReverse(h: HtmlMod): void {
+  const elements = h.querySelectorAll('*');
+  for (let index = elements.length - 1; index >= 0; index--) {
+    const element = elements[index];
+    if (expandableSelfClosing(element)) {
+      element.setAttribute('data-carta-self-closed', '');
+      element.expandSelfClosing();
+    }
+  }
+}
+
+function expectExpandEquivalence(source: string): void {
+  const eager = new HtmlMod(source);
+  expandAllReverse(eager);
+
+  const batched = new HtmlMod(source);
+  batched.batch(() => expandAllReverse(batched));
+
+  expect(batched.toString()).toBe(eager.toString());
+  expect(positionSnapshot(batched)).toBe(positionSnapshot(eager));
+}
+
+describe('expandSelfClosing batch equivalence', () => {
+  test('space-slash form <x-spacer /> across many elements', () => {
+    expectExpandEquivalence('<x-a /><x-b /><x-c /><x-d />');
+  });
+
+  test('no-space form <x-spacer/>', () => {
+    expectExpandEquivalence('<x-a/><x-b/><x-c/>');
+  });
+
+  test('mixed forms interleaved with real content and void elements', () => {
+    expectExpandEquivalence(
+      '<x-section><x-spacer /><img src="a.png"/><x-image src="b.gif"/><br/>text<x-divider /></x-section>'
+    );
+  });
+
+  test('nested self-closing elements', () => {
+    expectExpandEquivalence('<x-outer><x-inner /></x-outer><x-sibling />');
+  });
+
+  test('a self-closing element that also gets an attribute in the same batch flushes correctly', () => {
+    // setAttribute + expand on the SAME element must not produce overlapping
+    // edits — expand is structural and flushes any pending edit on it.
+    const source = '<x-a /><x-b />';
+    const eager = new HtmlMod(source);
+    for (const element of eager.querySelectorAll('x-a, x-b')) {
+      element.setAttribute('data-k', element.tagName);
+      element.expandSelfClosing();
+    }
+    const batched = new HtmlMod(source);
+    batched.batch(() => {
+      for (const element of batched.querySelectorAll('x-a, x-b')) {
+        element.setAttribute('data-k', element.tagName);
+        element.expandSelfClosing();
+      }
+    });
+    expect(batched.toString()).toBe(eager.toString());
+    expect(positionSnapshot(batched)).toBe(positionSnapshot(eager));
+  });
+
+  test('isSelfClosing read mid-batch reflects a queued expand', () => {
+    const h = new HtmlMod('<x-a /><x-b />');
+    h.batch(() => {
+      const a = h.querySelectorAll('x-a')[0];
+      expect(a.isSelfClosing).toBe(true);
+      a.expandSelfClosing();
+      // Queued expand must be visible to the structural read.
+      expect(a.isSelfClosing).toBe(false);
+    });
+    expect(h.toString()).toBe('<x-a></x-a><x-b />');
+  });
+});
+
 describe('structural batch guards', () => {
   test('children reads flush pending structural edits', () => {
     const h = new HtmlMod('<div><span>x</span></div>');

--- a/packages/html-mod/src/index.ts
+++ b/packages/html-mod/src/index.ts
@@ -1019,6 +1019,12 @@ export class HtmlModElement {
     };
 
     if (htmlMod.__isBatching) {
+      // Only the appendRight branch needs a same-position retry: two
+      // appendRights at one position apply LIFO, which the position sort
+      // can't reproduce. The overwrite branch spans this element's own tag
+      // tail — distinct elements can't overlap there, and a same-element edit
+      // is force-flushed by the structural conflict guard above — so it never
+      // collides; the __flushBatch overlap invariant is the backstop.
       if (operation.type === 'appendRight' && htmlMod.__batchAppendRightPositions.has(operation.start)) {
         // Same-position appendRights apply LIFO sequentially — flush and
         // re-run so the position is recomputed against the flushed state.

--- a/packages/html-mod/src/index.ts
+++ b/packages/html-mod/src/index.ts
@@ -223,8 +223,17 @@ export class HtmlMod {
    * Flush when the incoming edit cannot safely coexist with queued edits:
    *  - the same kind already queued on this element (repeat after/before/
    *    same-name attribute — sequential execution is order-sensitive there)
-   *  - prepend/append mixed with ANYTHING on the same element (they touch
-   *    the open-tag region and, for empty elements, share positions)
+   *  - a "structural" kind (`isStructuralBatchKind`: prepend, append, expand)
+   *    mixed with ANYTHING on the same element — they rewrite the open-tag /
+   *    content boundary, so positions shift or ranges overlap.
+   *
+   * NOTE on "structural": `isStructuralBatchKind` is the narrow set of
+   * open-tag-boundary rewriters used for THIS conflict check.
+   * `__queueStructuralBatchEdit` / `__batchHasStructuralEdits` use a broader
+   * notion — any queued NODE insertion (before/after included) — that gates
+   * `children`/`textContent`/`isSelfClosing` reads. The two overlap but are
+   * not the same set.
+   *
    * (Same-position appendRight conflicts — sequential LIFO — are handled at
    * queue time with a flush-and-retry, since the flush invalidates the
    * positions already computed by the caller.)

--- a/packages/html-mod/src/index.ts
+++ b/packages/html-mod/src/index.ts
@@ -31,6 +31,11 @@ import {
 } from './position-delta';
 import { atomicOverwrite, atomicAppendRight, atomicPrependLeft, atomicRemove } from './string-operations';
 
+/** Batch edit kinds that rewrite the open-tag/content boundary. */
+function isStructuralBatchKind(kind: string): boolean {
+  return kind === 'prepend' || kind === 'append' || kind === 'expand';
+}
+
 /** Sort rank for same-position batched edits — see __flushBatch. */
 function batchAnchorRank(edit: QueuedEdit): number {
   return edit.delta.operationType === 'appendRight' ? 0 : edit.delta.operationType === 'overwrite' ? 1 : 2;
@@ -227,9 +232,20 @@ export class HtmlMod {
   __flushBatchIfConflicting(element: SourceElement, kind: string): void {
     const kinds = this.__batchedElementKinds.get(element);
     if (!kinds) return;
-    const incomingIsContent = kind === 'prepend' || kind === 'append';
-    const queuedHasContent = kinds.has('prepend') || kinds.has('append');
-    if (kinds.has(kind) || incomingIsContent || queuedHasContent) {
+    // "Structural" kinds rewrite the open-tag/content boundary, so they
+    // conflict with ANY other edit on the same element (positions shift or
+    // ranges overlap): prepend/append insert into the content region, and
+    // expand rewrites the self-closing tail. An incoming structural edit
+    // flushes if anything is queued; any incoming edit flushes if a
+    // structural edit is queued.
+    let queuedHasStructural = false;
+    for (const queued of kinds) {
+      if (isStructuralBatchKind(queued)) {
+        queuedHasStructural = true;
+        break;
+      }
+    }
+    if (kinds.has(kind) || isStructuralBatchKind(kind) || queuedHasStructural) {
       this.__flushBatch();
     }
   }
@@ -949,33 +965,41 @@ export class HtmlModElement {
    * siblings.
    */
   expandSelfClosing(): this {
-    this.__htmlMod.__flushBatch();
+    // A queued edit on this element would make the open-tag positions read
+    // below stale — flush it first. Distinct elements never conflict, so the
+    // hot loop (expanding every self-closing element in a document) stays
+    // flush-free.
+    this.__htmlMod.__flushBatchIfConflicting(this.__element, 'expand');
     if (!isSelfClosing(this.__element)) return this;
 
-    // Invalidate cached outerHTML since we're changing the element's structure
-    this.__htmlMod.__cachedOuterHTML.delete(this.__element);
-
-    const endIndex = this.__element.source.openTag.endIndex;
+    const element = this.__element;
+    const htmlMod = this.__htmlMod;
+    const endIndex = element.source.openTag.endIndex;
     // Use the open tag's source casing for the close tag. The parser pairs
     // open/close tags case-sensitively, so a synthesized lowercase close tag
     // on a mixed-case element (`<X-Image/>` -> `<X-Image></x-image>`) would not
     // re-pair on the next parse, leaving an orphaned close tag.
-    const closeTag = makeClosingTag(this.__element.source.openTag.name);
+    const closeTag = makeClosingTag(element.source.openTag.name);
 
+    // Compute the single string operation + the resulting open-tag end, in
+    // pre-batch coordinates. Raw-source reads are safe: the conflict flush
+    // above guarantees this element has no queued edit, so its own open-tag
+    // bytes are unshifted.
+    let operation: { type: 'overwrite' | 'appendRight'; start: number; end: number; content: string };
     let openTagEnd: number;
-    if (hasTrailingSlash(this.__element, this.__htmlMod.__source)) {
+    if (hasTrailingSlash(element, htmlMod.__sourceRaw)) {
       // Replace ` />` or `/>` with `></tag>`
       // Walk back from `/` to skip whitespace before the slash
       let start = endIndex; // endIndex points to `>`
       start--; // now at `/`
-      while (start > 0 && this.__htmlMod.__source[start - 1] === ' ') {
+      while (start > 0 && htmlMod.__sourceRaw[start - 1] === ' ') {
         start--;
       }
-      atomicOverwrite(this.__htmlMod, start, endIndex + 1, `>${closeTag}`, this.__element);
+      operation = { type: 'overwrite', start, end: endIndex + 1, content: `>${closeTag}` };
       // The new `>` lands where the `/` (and any preceding spaces) began.
       openTagEnd = start;
     } else {
-      atomicAppendRight(this.__htmlMod, endIndex + 1, closeTag, this.__element);
+      operation = { type: 'appendRight', start: endIndex + 1, end: endIndex + 1, content: closeTag };
       // The `>` is unchanged.
       openTagEnd = endIndex;
     }
@@ -983,9 +1007,47 @@ export class HtmlModElement {
     // Fully sync the AST to reflect the new explicit close tag: update the
     // open-tag end, attach the close tag, and fix element.endIndex. Leaving any
     // of these stale corrupts a later before()/after()/append()/innerHTML.
-    const closeTagStart = openTagEnd + 1;
-    const closeTagEnd = closeTagStart + closeTag.length; // exclusive, matches parser
-    AstManipulator.convertToRegularTag(this.__element, openTagEnd, closeTagStart, closeTagEnd);
+    // Runs at flush (batched) or immediately (eager); `shift` is the
+    // cumulative delta of edits sorted before this one.
+    const finalize = (shift: number): void => {
+      // Invalidate cached outerHTML — the element's structure changed.
+      htmlMod.__cachedOuterHTML.delete(element);
+      const shiftedOpenTagEnd = openTagEnd + shift;
+      const closeTagStart = shiftedOpenTagEnd + 1;
+      const closeTagEnd = closeTagStart + closeTag.length; // exclusive, matches parser
+      AstManipulator.convertToRegularTag(element, shiftedOpenTagEnd, closeTagStart, closeTagEnd);
+    };
+
+    if (htmlMod.__isBatching) {
+      if (operation.type === 'appendRight' && htmlMod.__batchAppendRightPositions.has(operation.start)) {
+        // Same-position appendRights apply LIFO sequentially — flush and
+        // re-run so the position is recomputed against the flushed state.
+        htmlMod.__flushBatch();
+        return this.expandSelfClosing();
+      }
+      htmlMod.__queueStructuralBatchEdit(
+        {
+          start: operation.start,
+          end: operation.end,
+          content: operation.content,
+          delta:
+            operation.type === 'overwrite'
+              ? calculateOverwriteDelta(operation.start, operation.end, operation.content)
+              : calculateAppendRightDelta(operation.start, operation.content),
+          element,
+          finalize,
+        },
+        'expand'
+      );
+      return this;
+    }
+
+    if (operation.type === 'overwrite') {
+      atomicOverwrite(htmlMod, operation.start, operation.end, operation.content, element);
+    } else {
+      atomicAppendRight(htmlMod, operation.start, operation.content, element);
+    }
+    finalize(0);
 
     return this;
   }


### PR DESCRIPTION
## Problem

`expandSelfClosing()` flushed the batch and applied its edit eagerly — an O(document) string splice + AST position walk per call. Expanding every self-closing element in a document (the parcel tiptap preprocess `expandSelfClosingElements` loop — `<x-spacer />`, `<x-image />`, etc.) is therefore quadratic in document size. It was the one preprocess write loop that couldn't adopt `batch()` (ciolabs#58).

## Change

Make `expandSelfClosing()` batch-aware. Inside a batch it queues its edit — the ` />` → `></tag>` overwrite (or, for the no-slash case, an appendRight of the close tag) plus the deferred `convertToRegularTag` AST update, shifted by the batch's cumulative delta — and applies it at flush. Outside a batch, behavior is unchanged.

`expandSelfClosing` is registered as a **structural** batch kind alongside `prepend`/`append` (extracted `isStructuralBatchKind`): it rewrites the open-tag boundary, so it conflicts with *any* other queued edit on the same element (an incoming expand flushes if anything is queued; any incoming edit flushes if an expand is queued). This keeps a mixed same-element sequence — e.g. `setAttribute(marker)` then `expandSelfClosing()` — byte-identical to unbatched. `isSelfClosing` / `children` / `textContent` reads flush a pending expand (via the existing structural-pending guard) so they never see stale structure. The no-slash appendRight case reuses the same-position LIFO flush-and-retry as `append`.

To actually win, callers apply the two operations in separate batched passes over distinct elements (attribute marks, then expansions) — see the measurement below.

## Measurements

43KB document, 400 self-closing elements, two batched passes (mark all → expand all), asserted byte-equivalent to the eager per-element sequence:

| doc | self-closing | eager | batched |
|---|---|---|---|
| 50 sections | 100 | 3.0ms | 1.0ms |
| 100 sections | 200 | 7.3ms | 1.1ms |
| 200 sections | 400 | **26.2ms → 2.3ms (11×)** |

Eager grows quadratically; batched stays linear.

## Testing

- 6 new equivalence tests (`batch-structural.test.ts`) — byte + full AST position-snapshot equivalence for space-slash / no-space / mixed-with-void / nested forms, the same-element setAttribute+expand flush case, and the mid-batch `isSelfClosing` read.
- Full suite: **638/638** (all pre-existing batch + expand-self-closing + adversarial suites unchanged).
- eslint + tsc clean; build green.

## Notes

Follow-up parcel PR restructures `expandSelfClosingElements` into the collect → batch-mark → batch-expand three passes to consume this (the last preprocess quadratic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
